### PR TITLE
epic: host question panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 archives
+scripts

--- a/src/components/host/HostQuestionAnswers.tsx
+++ b/src/components/host/HostQuestionAnswers.tsx
@@ -1,0 +1,108 @@
+import type { Question } from '@/db'
+
+function MultipleChoice({ options, answer }: { options: string[]; answer: string }) {
+  return (
+    <ol className="flex flex-col gap-2">
+      {options.map((option, i) => {
+        const isCorrect = option === answer
+        return (
+          <li
+            key={i}
+            className="flex items-center gap-3 px-4 py-2.5 rounded-lg border text-sm font-medium"
+            style={{
+              borderColor: isCorrect ? '#16a34a' : 'var(--color-border)',
+              background: isCorrect ? '#f0fdf4' : 'var(--color-surface)',
+              color: isCorrect ? '#15803d' : 'var(--color-ink)',
+              outline: isCorrect ? '2px solid #16a34a' : 'none',
+              outlineOffset: '-2px',
+            }}
+          >
+            <span
+              className="w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+              style={{
+                background: isCorrect ? '#16a34a' : 'var(--color-border)',
+                color: isCorrect ? '#fff' : 'var(--color-muted)',
+              }}
+            >
+              {String.fromCharCode(65 + i)}
+            </span>
+            {option}
+            {isCorrect && (
+              <span className="ml-auto text-xs font-semibold" style={{ color: '#16a34a' }}>
+                ✓ Correct
+              </span>
+            )}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+function TrueFalse({ answer }: { answer: string }) {
+  return (
+    <div className="flex gap-3">
+      {(['True', 'False'] as const).map(option => {
+        const isCorrect = option === answer
+        return (
+          <div
+            key={option}
+            className="flex-1 flex items-center justify-center gap-2 py-3 rounded-lg border text-sm font-bold"
+            style={{
+              borderColor: isCorrect ? '#16a34a' : 'var(--color-border)',
+              background: isCorrect ? '#f0fdf4' : 'var(--color-surface)',
+              color: isCorrect ? '#15803d' : 'var(--color-muted)',
+              outline: isCorrect ? '2px solid #16a34a' : 'none',
+              outlineOffset: '-2px',
+            }}
+          >
+            {isCorrect && <span>✓</span>}
+            {option}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function OpenEnded({ answer }: { answer: string }) {
+  return (
+    <div
+      className="px-4 py-3 rounded-lg border text-sm"
+      style={{
+        borderColor: 'var(--color-border)',
+        background: 'var(--color-surface)',
+        color: 'var(--color-ink)',
+      }}
+    >
+      <p
+        className="text-xs font-semibold uppercase tracking-wide mb-1"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        Expected answer
+      </p>
+      <p className="font-medium">{answer}</p>
+    </div>
+  )
+}
+
+interface HostQuestionAnswersProps {
+  question: Question
+}
+
+export function HostQuestionAnswers({ question }: HostQuestionAnswersProps) {
+  const { type, options, answer } = question
+  return (
+    <div className="flex flex-col gap-2">
+      <p
+        className="text-xs font-semibold uppercase tracking-wide"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        Answers
+      </p>
+      {type === 'multiple_choice' && <MultipleChoice options={options} answer={answer} />}
+      {type === 'true_false' && <TrueFalse answer={answer} />}
+      {type === 'open_ended' && <OpenEnded answer={answer} />}
+    </div>
+  )
+}

--- a/src/components/host/HostQuestionHeader.tsx
+++ b/src/components/host/HostQuestionHeader.tsx
@@ -1,0 +1,54 @@
+import type { Question, GameQuestion } from '@/db'
+import { Badge } from '@/components/ui'
+
+const TYPE_LABEL: Record<Question['type'], string> = {
+  multiple_choice: 'Multiple choice',
+  true_false: 'True / False',
+  open_ended: 'Open ended',
+}
+
+const TYPE_COLOR: Record<Question['type'], string> = {
+  multiple_choice: '#2563eb',
+  true_false: '#7c3aed',
+  open_ended: '#0891b2',
+}
+
+const STATUS_LABEL: Record<GameQuestion['status'], string> = {
+  pending: 'Pending',
+  correct: 'Correct',
+  incorrect: 'Incorrect',
+  skipped: 'Skipped',
+}
+
+const STATUS_COLOR: Record<GameQuestion['status'], string> = {
+  pending: '#6b7280',
+  correct: '#16a34a',
+  incorrect: '#dc2626',
+  skipped: '#d97706',
+}
+
+interface HostQuestionHeaderProps {
+  question: Question
+  gameQuestion: GameQuestion
+}
+
+export function HostQuestionHeader({ question, gameQuestion }: HostQuestionHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 flex-wrap">
+        <Badge color={TYPE_COLOR[question.type]} style={{ color: '#fff' }}>
+          {TYPE_LABEL[question.type]}
+        </Badge>
+        <Badge color={STATUS_COLOR[gameQuestion.status]} style={{ color: '#fff' }}>
+          {STATUS_LABEL[gameQuestion.status]}
+        </Badge>
+      </div>
+      <h2
+        className="text-xl font-bold leading-snug"
+        style={{ fontFamily: 'Playfair Display, serif', color: 'var(--color-ink)' }}
+      >
+        {question.title}
+      </h2>
+    </div>
+  )
+}

--- a/src/components/host/HostQuestionMedia.tsx
+++ b/src/components/host/HostQuestionMedia.tsx
@@ -1,0 +1,41 @@
+import type { Question } from '@/db'
+
+interface HostQuestionMediaProps {
+  question: Question
+}
+
+export function HostQuestionMedia({ question }: HostQuestionMediaProps) {
+  const { media, mediaType } = question
+  if (!media || !mediaType) return null
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p
+        className="text-xs font-semibold uppercase tracking-wide"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        Media
+      </p>
+      <div
+        className="rounded-lg border overflow-hidden"
+        style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+      >
+        {mediaType === 'image' && (
+          <img src={media} alt="Question media" className="w-full max-h-72 object-contain" />
+        )}
+        {mediaType === 'audio' && (
+          <div className="p-4">
+            <audio controls src={media} className="w-full">
+              Your browser does not support the audio element.
+            </audio>
+          </div>
+        )}
+        {mediaType === 'video' && (
+          <video controls src={media} className="w-full max-h-72">
+            Your browser does not support the video element.
+          </video>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/host/HostQuestionPanel.tsx
+++ b/src/components/host/HostQuestionPanel.tsx
@@ -1,0 +1,22 @@
+import type { Question, GameQuestion, Game } from '@/db'
+import { HostQuestionHeader } from './HostQuestionHeader'
+import { HostQuestionAnswers } from './HostQuestionAnswers'
+import { HostQuestionMedia } from './HostQuestionMedia'
+import { HostVisibilityToggles } from './HostVisibilityToggles'
+
+interface HostQuestionPanelProps {
+  question: Question
+  gameQuestion: GameQuestion
+  game: Game
+}
+
+export function HostQuestionPanel({ question, gameQuestion, game }: HostQuestionPanelProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <HostQuestionHeader question={question} gameQuestion={gameQuestion} />
+      <HostQuestionAnswers question={question} />
+      {question.media && question.mediaType && <HostQuestionMedia question={question} />}
+      <HostVisibilityToggles game={game} />
+    </div>
+  )
+}

--- a/src/components/host/HostVisibilityToggles.tsx
+++ b/src/components/host/HostVisibilityToggles.tsx
@@ -1,0 +1,90 @@
+import type { Game } from '@/db'
+import { useGameVisibility } from '@/hooks/useGameVisibility'
+import type { VisibilityState } from '@/hooks/useGameVisibility'
+
+interface ToggleProps {
+  label: string
+  hint: string
+  checked: boolean
+  disabled: boolean
+  onChange: () => void
+}
+
+function Toggle({ label, hint, checked, disabled, onChange }: ToggleProps) {
+  return (
+    <label
+      className="flex items-center justify-between gap-4 cursor-pointer select-none"
+      style={{ opacity: disabled ? 0.6 : 1 }}
+    >
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium" style={{ color: 'var(--color-ink)' }}>
+          {label}
+        </span>
+        <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+          {hint}
+        </span>
+      </div>
+      <button
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={onChange}
+        className="relative shrink-0 w-11 h-6 rounded-full border-2 transition-colors"
+        style={{
+          background: checked ? '#16a34a' : 'var(--color-border)',
+          borderColor: checked ? '#16a34a' : 'var(--color-border)',
+        }}
+      >
+        <span
+          className="block w-4 h-4 rounded-full bg-white shadow transition-transform"
+          style={{ transform: checked ? 'translateX(20px)' : 'translateX(2px)' }}
+        />
+      </button>
+    </label>
+  )
+}
+
+const TOGGLES: Array<{ key: keyof VisibilityState; label: string; hint: string }> = [
+  { key: 'showQuestion', label: 'Show question', hint: 'Players can see the question text' },
+  { key: 'showAnswers', label: 'Show answers', hint: 'Players can see the answer options' },
+  { key: 'showMedia', label: 'Show media', hint: 'Players can see images, audio, or video' },
+]
+
+interface HostVisibilityTogglesProps {
+  game: Game
+}
+
+export function HostVisibilityToggles({ game }: HostVisibilityTogglesProps) {
+  const { visibility, toggle, saving, error } = useGameVisibility(game)
+  return (
+    <div className="flex flex-col gap-2">
+      <p
+        className="text-xs font-semibold uppercase tracking-wide"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        Visibility
+      </p>
+      <div
+        className="flex flex-col gap-4 rounded-lg border p-4"
+        style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+      >
+        {TOGGLES.map(({ key, label, hint }) => (
+          <Toggle
+            key={key}
+            label={label}
+            hint={hint}
+            checked={visibility[key]}
+            disabled={saving}
+            onChange={() => toggle(key)}
+          />
+        ))}
+      </div>
+      {error && (
+        <p className="text-xs" style={{ color: 'var(--color-red)' }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useGameVisibility.ts
+++ b/src/hooks/useGameVisibility.ts
@@ -1,0 +1,60 @@
+import { useState, useCallback } from 'react'
+import { db } from '@/db'
+import { transportManager } from '@/transport'
+import type { Game } from '@/db'
+
+export interface VisibilityState {
+  showQuestion: boolean
+  showAnswers: boolean
+  showMedia: boolean
+}
+
+export interface UseGameVisibilityResult {
+  visibility: VisibilityState
+  toggle: (key: keyof VisibilityState) => Promise<void>
+  saving: boolean
+  error: string | null
+}
+
+export function useGameVisibility(game: Game): UseGameVisibilityResult {
+  const [visibility, setVisibility] = useState<VisibilityState>({
+    showQuestion: game.showQuestion,
+    showAnswers: game.showAnswers,
+    showMedia: game.showMedia,
+  })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const toggle = useCallback(
+    async (key: keyof VisibilityState) => {
+      const next: VisibilityState = { ...visibility, [key]: !visibility[key] }
+      setVisibility(next)
+      setSaving(true)
+      setError(null)
+
+      try {
+        await db.games.update(game.id, {
+          showQuestion: next.showQuestion,
+          showAnswers: next.showAnswers,
+          showMedia: next.showMedia,
+          updatedAt: Date.now(),
+        })
+
+        transportManager.send({
+          type: 'VISIBILITY',
+          showQuestion: next.showQuestion,
+          showAnswers: next.showAnswers,
+          showMedia: next.showMedia,
+        })
+      } catch (err) {
+        setVisibility(visibility)
+        setError(err instanceof Error ? err.message : 'Failed to save visibility')
+      } finally {
+        setSaving(false)
+      }
+    },
+    [game.id, visibility]
+  )
+
+  return { visibility, toggle, saving, error }
+}

--- a/src/test/host/HostQuestionAnswers.test.tsx
+++ b/src/test/host/HostQuestionAnswers.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HostQuestionAnswers } from '@/components/host/HostQuestionAnswers'
+import type { Question } from '@/db'
+
+const BASE: Question = {
+  id: 'q1',
+  title: 'Q',
+  type: 'multiple_choice',
+  options: ['Paris', 'Lyon', 'Marseille', 'Nice'],
+  answer: 'Paris',
+  description: '',
+  difficulty: null,
+  tags: [],
+  media: null,
+  mediaType: null,
+  createdAt: 0,
+  updatedAt: 0,
+}
+function q(o: Partial<Question>): Question {
+  return { ...BASE, ...o }
+}
+
+describe('HostQuestionAnswers — multiple_choice', () => {
+  it('renders all four options', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getByText('Paris')).toBeInTheDocument()
+    expect(screen.getByText('Lyon')).toBeInTheDocument()
+    expect(screen.getByText('Marseille')).toBeInTheDocument()
+    expect(screen.getByText('Nice')).toBeInTheDocument()
+  })
+  it('highlights the correct option with green background', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getByText('Paris').closest('li')).toHaveStyle({ background: '#f0fdf4' })
+  })
+  it('does not highlight incorrect options', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getByText('Lyon').closest('li')).not.toHaveStyle({ background: '#f0fdf4' })
+  })
+  it('shows "✓ Correct" marker only on the correct option', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getAllByText('✓ Correct')).toHaveLength(1)
+  })
+  it('renders alphabetic labels A–D', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getByText('A')).toBeInTheDocument()
+    expect(screen.getByText('B')).toBeInTheDocument()
+    expect(screen.getByText('C')).toBeInTheDocument()
+    expect(screen.getByText('D')).toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionAnswers — true_false', () => {
+  const tf = q({ type: 'true_false', options: ['True', 'False'], answer: 'True' })
+  it('renders True and False options', () => {
+    render(<HostQuestionAnswers question={tf} />)
+    expect(screen.getByText('True')).toBeInTheDocument()
+    expect(screen.getByText('False')).toBeInTheDocument()
+  })
+  it('highlights True when answer is True', () => {
+    render(<HostQuestionAnswers question={tf} />)
+    expect(screen.getByText('True').closest('div')).toHaveStyle({ background: '#f0fdf4' })
+    expect(screen.getByText('False').closest('div')).not.toHaveStyle({ background: '#f0fdf4' })
+  })
+  it('highlights False when answer is False', () => {
+    render(
+      <HostQuestionAnswers
+        question={q({ type: 'true_false', options: ['True', 'False'], answer: 'False' })}
+      />
+    )
+    expect(screen.getByText('False').closest('div')).toHaveStyle({ background: '#f0fdf4' })
+    expect(screen.getByText('True').closest('div')).not.toHaveStyle({ background: '#f0fdf4' })
+  })
+})
+
+describe('HostQuestionAnswers — open_ended', () => {
+  const oe = q({ type: 'open_ended', options: [], answer: 'The Eiffel Tower' })
+  it('renders the expected answer text', () => {
+    render(<HostQuestionAnswers question={oe} />)
+    expect(screen.getByText('The Eiffel Tower')).toBeInTheDocument()
+  })
+  it('renders the "Expected answer" label', () => {
+    render(<HostQuestionAnswers question={oe} />)
+    expect(screen.getByText('Expected answer')).toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionAnswers — section label', () => {
+  it('renders "Answers" heading', () => {
+    render(<HostQuestionAnswers question={q({})} />)
+    expect(screen.getByText('Answers')).toBeInTheDocument()
+  })
+})

--- a/src/test/host/HostQuestionHeader.test.tsx
+++ b/src/test/host/HostQuestionHeader.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HostQuestionHeader } from '@/components/host/HostQuestionHeader'
+import type { Question, GameQuestion } from '@/db'
+
+const BASE_Q: Question = {
+  id: 'q1',
+  title: 'What is the capital of France?',
+  type: 'multiple_choice',
+  options: ['Paris', 'Lyon', 'Marseille', 'Nice'],
+  answer: 'Paris',
+  description: '',
+  difficulty: null,
+  tags: [],
+  media: null,
+  mediaType: null,
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const BASE_GQ: GameQuestion = {
+  id: 'gq1',
+  gameId: 'g1',
+  questionId: 'q1',
+  roundId: 'r1',
+  order: 0,
+  status: 'pending',
+}
+
+function q(o: Partial<Question> = {}): Question {
+  return { ...BASE_Q, ...o }
+}
+function gq(o: Partial<GameQuestion> = {}): GameQuestion {
+  return { ...BASE_GQ, ...o }
+}
+
+describe('HostQuestionHeader — title', () => {
+  it('renders the question title', () => {
+    render(<HostQuestionHeader question={q()} gameQuestion={gq()} />)
+    expect(screen.getByText('What is the capital of France?')).toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionHeader — type badge', () => {
+  it('shows "Multiple choice" for multiple_choice', () => {
+    render(<HostQuestionHeader question={q({ type: 'multiple_choice' })} gameQuestion={gq()} />)
+    expect(screen.getByText('Multiple choice')).toBeInTheDocument()
+  })
+  it('shows "True / False" for true_false', () => {
+    render(<HostQuestionHeader question={q({ type: 'true_false' })} gameQuestion={gq()} />)
+    expect(screen.getByText('True / False')).toBeInTheDocument()
+  })
+  it('shows "Open ended" for open_ended', () => {
+    render(<HostQuestionHeader question={q({ type: 'open_ended' })} gameQuestion={gq()} />)
+    expect(screen.getByText('Open ended')).toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionHeader — status badge', () => {
+  const cases: Array<[GameQuestion['status'], string, string]> = [
+    ['pending', 'Pending', '#6b7280'],
+    ['correct', 'Correct', '#16a34a'],
+    ['incorrect', 'Incorrect', '#dc2626'],
+    ['skipped', 'Skipped', '#d97706'],
+  ]
+  it.each(cases)('renders "%s" label and correct colour', (status, label, color) => {
+    render(<HostQuestionHeader question={q()} gameQuestion={gq({ status })} />)
+    const badge = screen.getByText(label)
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveStyle({ background: color })
+  })
+})

--- a/src/test/host/HostQuestionMedia.test.tsx
+++ b/src/test/host/HostQuestionMedia.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { HostQuestionMedia } from '@/components/host/HostQuestionMedia'
+import type { Question } from '@/db'
+
+const BASE: Question = {
+  id: 'q1',
+  title: 'Q',
+  type: 'multiple_choice',
+  options: [],
+  answer: '',
+  description: '',
+  difficulty: null,
+  tags: [],
+  media: null,
+  mediaType: null,
+  createdAt: 0,
+  updatedAt: 0,
+}
+function q(o: Partial<Question>): Question {
+  return { ...BASE, ...o }
+}
+
+describe('HostQuestionMedia — no media', () => {
+  it('renders nothing when media is null', () => {
+    const { container } = render(<HostQuestionMedia question={q({})} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders nothing when only media is set', () => {
+    const { container } = render(
+      <HostQuestionMedia question={q({ media: 'https://x.com/img.png', mediaType: null })} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders nothing when only mediaType is set', () => {
+    const { container } = render(
+      <HostQuestionMedia question={q({ media: null, mediaType: 'image' })} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('HostQuestionMedia — image', () => {
+  const imgQ = q({ media: 'https://example.com/photo.jpg', mediaType: 'image' })
+  it('renders an img with correct src', () => {
+    render(<HostQuestionMedia question={imgQ} />)
+    const img = screen.getByRole('img')
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src', 'https://example.com/photo.jpg')
+  })
+  it('renders "Media" label', () => {
+    render(<HostQuestionMedia question={imgQ} />)
+    expect(screen.getByText('Media')).toBeInTheDocument()
+  })
+  it('does not render audio or video', () => {
+    render(<HostQuestionMedia question={imgQ} />)
+    expect(document.querySelector('audio')).not.toBeInTheDocument()
+    expect(document.querySelector('video')).not.toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionMedia — audio', () => {
+  const audioQ = q({ media: 'https://example.com/clip.mp3', mediaType: 'audio' })
+  it('renders audio with correct src and controls', () => {
+    render(<HostQuestionMedia question={audioQ} />)
+    const audio = document.querySelector('audio')
+    expect(audio).toBeInTheDocument()
+    expect(audio).toHaveAttribute('src', 'https://example.com/clip.mp3')
+    expect(audio).toHaveAttribute('controls')
+  })
+  it('does not render img or video', () => {
+    render(<HostQuestionMedia question={audioQ} />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(document.querySelector('video')).not.toBeInTheDocument()
+  })
+})
+
+describe('HostQuestionMedia — video', () => {
+  const videoQ = q({ media: 'https://example.com/clip.mp4', mediaType: 'video' })
+  it('renders video with correct src and controls', () => {
+    render(<HostQuestionMedia question={videoQ} />)
+    const video = document.querySelector('video')
+    expect(video).toBeInTheDocument()
+    expect(video).toHaveAttribute('src', 'https://example.com/clip.mp4')
+    expect(video).toHaveAttribute('controls')
+  })
+  it('does not render img or audio', () => {
+    render(<HostQuestionMedia question={videoQ} />)
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(document.querySelector('audio')).not.toBeInTheDocument()
+  })
+})

--- a/src/test/host/HostQuestionPanel.test.tsx
+++ b/src/test/host/HostQuestionPanel.test.tsx
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HostQuestionPanel } from '@/components/host/HostQuestionPanel'
+import type { Question, GameQuestion, Game } from '@/db'
+
+vi.mock('@/db', () => ({ db: { games: { update: vi.fn() } } }))
+vi.mock('@/transport', () => ({ transportManager: { send: vi.fn() } }))
+
+import { db } from '@/db'
+import { transportManager } from '@/transport'
+
+const BASE_GAME: Game = {
+  id: 'g1',
+  name: 'Quiz Night',
+  status: 'active',
+  transportMode: 'auto',
+  roomId: 'ABC123',
+  passphrase: 'a-b-c-d',
+  scoringEnabled: true,
+  showQuestion: true,
+  showAnswers: false,
+  showMedia: true,
+  maxTeams: 0,
+  maxPerTeam: 0,
+  allowIndividual: true,
+  roundIds: [],
+  currentRoundIdx: 0,
+  currentQuestionIdx: 0,
+  buzzerLocked: false,
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const BASE_GQ: GameQuestion = {
+  id: 'gq1',
+  gameId: 'g1',
+  questionId: 'q1',
+  roundId: 'r1',
+  order: 0,
+  status: 'pending',
+}
+
+function makeQ(o: Partial<Question> = {}): Question {
+  return {
+    id: 'q1',
+    title: 'What is the capital of France?',
+    type: 'multiple_choice',
+    options: ['Paris', 'Lyon', 'Marseille', 'Nice'],
+    answer: 'Paris',
+    description: '',
+    difficulty: null,
+    tags: [],
+    media: null,
+    mediaType: null,
+    createdAt: 0,
+    updatedAt: 0,
+    ...o,
+  }
+}
+
+function rp(question = makeQ(), gq = BASE_GQ, game = BASE_GAME) {
+  return render(<HostQuestionPanel question={question} gameQuestion={gq} game={game} />)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(db.games.update).mockResolvedValue(1)
+})
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — header', () => {
+  it('renders the question title', () => {
+    rp()
+    expect(screen.getByText('What is the capital of France?')).toBeInTheDocument()
+  })
+  it('renders the type badge', () => {
+    rp(makeQ({ type: 'true_false' }))
+    expect(screen.getByText('True / False')).toBeInTheDocument()
+  })
+  it('renders the status badge', () => {
+    rp(makeQ(), { ...BASE_GQ, status: 'correct' })
+    expect(screen.getByText('Correct')).toBeInTheDocument()
+  })
+  it('host always sees title regardless of showQuestion flag', () => {
+    rp(makeQ(), BASE_GQ, { ...BASE_GAME, showQuestion: false })
+    expect(screen.getByText('What is the capital of France?')).toBeInTheDocument()
+  })
+})
+
+// ── Answers ───────────────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — answers', () => {
+  it('renders all options for multiple_choice', () => {
+    rp()
+    expect(screen.getByText('Paris')).toBeInTheDocument()
+    expect(screen.getByText('Lyon')).toBeInTheDocument()
+    expect(screen.getByText('Marseille')).toBeInTheDocument()
+    expect(screen.getByText('Nice')).toBeInTheDocument()
+  })
+  it('highlights the correct answer', () => {
+    rp()
+    expect(screen.getByText('✓ Correct')).toBeInTheDocument()
+  })
+  it('renders True/False for true_false', () => {
+    rp(makeQ({ type: 'true_false', options: ['True', 'False'], answer: 'True' }))
+    expect(screen.getByText('True')).toBeInTheDocument()
+    expect(screen.getByText('False')).toBeInTheDocument()
+  })
+  it('renders expected answer for open_ended', () => {
+    rp(makeQ({ type: 'open_ended', options: [], answer: 'The Eiffel Tower' }))
+    expect(screen.getByText('The Eiffel Tower')).toBeInTheDocument()
+    expect(screen.getByText('Expected answer')).toBeInTheDocument()
+  })
+  it('host always sees answers regardless of showAnswers flag', () => {
+    rp(makeQ(), BASE_GQ, { ...BASE_GAME, showAnswers: false })
+    expect(screen.getByText('Paris')).toBeInTheDocument()
+    expect(screen.getByText('✓ Correct')).toBeInTheDocument()
+  })
+})
+
+// ── Media ─────────────────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — media', () => {
+  it('renders media when question has image', () => {
+    rp(makeQ({ media: 'https://example.com/img.jpg', mediaType: 'image' }))
+    expect(screen.getByRole('img')).toBeInTheDocument()
+  })
+  it('does not render media section when media is null', () => {
+    rp()
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(document.querySelector('audio')).not.toBeInTheDocument()
+    expect(document.querySelector('video')).not.toBeInTheDocument()
+  })
+  it('host always sees media regardless of showMedia flag', () => {
+    rp(makeQ({ media: 'https://example.com/img.jpg', mediaType: 'image' }), BASE_GQ, {
+      ...BASE_GAME,
+      showMedia: false,
+    })
+    expect(screen.getByRole('img')).toBeInTheDocument()
+  })
+})
+
+// ── Visibility toggles ────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — visibility toggles', () => {
+  it('renders all three toggle switches', () => {
+    rp()
+    expect(screen.getAllByRole('switch')).toHaveLength(3)
+  })
+  it('reflects game visibility state in toggles', () => {
+    rp(makeQ(), BASE_GQ, { ...BASE_GAME, showQuestion: false, showAnswers: true, showMedia: false })
+    const [q, a, m] = screen.getAllByRole('switch')
+    expect(q).toHaveAttribute('aria-checked', 'false')
+    expect(a).toHaveAttribute('aria-checked', 'true')
+    expect(m).toHaveAttribute('aria-checked', 'false')
+  })
+  it('persists to DB when a toggle is clicked', async () => {
+    rp()
+    await userEvent.click(screen.getByRole('switch', { name: 'Show answers' }))
+    expect(db.games.update).toHaveBeenCalledWith(
+      'g1',
+      expect.objectContaining({ showAnswers: true })
+    )
+  })
+  it('emits VISIBILITY event with correct payload', async () => {
+    rp()
+    await userEvent.click(screen.getByRole('switch', { name: 'Show answers' }))
+    expect(transportManager.send).toHaveBeenCalledWith({
+      type: 'VISIBILITY',
+      showQuestion: true,
+      showAnswers: true,
+      showMedia: true,
+    })
+  })
+  it('shows error message if DB write fails', async () => {
+    vi.mocked(db.games.update).mockRejectedValueOnce(new Error('Write failed'))
+    rp()
+    await userEvent.click(screen.getByRole('switch', { name: 'Show question' }))
+    expect(screen.getByText('Write failed')).toBeInTheDocument()
+  })
+})
+
+// ── Layout order ──────────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — layout order', () => {
+  it('renders header before answers before toggles', () => {
+    rp()
+    const title = screen.getByText('What is the capital of France?')
+    const answers = screen.getByText('Answers')
+    const toggles = screen.getByText('Visibility')
+    expect(title.compareDocumentPosition(answers) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(answers.compareDocumentPosition(toggles) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+})
+
+// ── All question types ────────────────────────────────────────────────────────
+
+describe('HostQuestionPanel — all question types render without error', () => {
+  it('multiple_choice', () => {
+    expect(() => rp()).not.toThrow()
+  })
+  it('true_false', () => {
+    expect(() =>
+      rp(makeQ({ type: 'true_false', options: ['True', 'False'], answer: 'False' }))
+    ).not.toThrow()
+  })
+  it('open_ended', () => {
+    expect(() => rp(makeQ({ type: 'open_ended', options: [], answer: 'Paris' }))).not.toThrow()
+  })
+})

--- a/src/test/host/HostVisibilityToggles.test.tsx
+++ b/src/test/host/HostVisibilityToggles.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HostVisibilityToggles } from '@/components/host/HostVisibilityToggles'
+import type { Game } from '@/db'
+
+const mockToggle = vi.fn()
+
+vi.mock('@/hooks/useGameVisibility', () => ({
+  useGameVisibility: vi.fn(() => ({
+    visibility: { showQuestion: true, showAnswers: false, showMedia: true },
+    toggle: mockToggle,
+    saving: false,
+    error: null,
+  })),
+}))
+
+import { useGameVisibility } from '@/hooks/useGameVisibility'
+
+const GAME: Game = {
+  id: 'g1',
+  name: 'Test',
+  status: 'active',
+  transportMode: 'auto',
+  roomId: null,
+  passphrase: null,
+  scoringEnabled: true,
+  showQuestion: true,
+  showAnswers: false,
+  showMedia: true,
+  maxTeams: 0,
+  maxPerTeam: 0,
+  allowIndividual: true,
+  roundIds: [],
+  currentRoundIdx: 0,
+  currentQuestionIdx: 0,
+  buzzerLocked: false,
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+const defaultMock = {
+  visibility: { showQuestion: true, showAnswers: false, showMedia: true },
+  toggle: mockToggle,
+  saving: false,
+  error: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useGameVisibility).mockReturnValue(defaultMock)
+})
+
+describe('HostVisibilityToggles — rendering', () => {
+  it('renders three toggle switches', () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    expect(screen.getAllByRole('switch')).toHaveLength(3)
+  })
+  it('renders all three labels', () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    expect(screen.getByText('Show question')).toBeInTheDocument()
+    expect(screen.getByText('Show answers')).toBeInTheDocument()
+    expect(screen.getByText('Show media')).toBeInTheDocument()
+  })
+  it('reflects aria-checked from visibility state', () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    const [q, a, m] = screen.getAllByRole('switch')
+    expect(q).toHaveAttribute('aria-checked', 'true')
+    expect(a).toHaveAttribute('aria-checked', 'false')
+    expect(m).toHaveAttribute('aria-checked', 'true')
+  })
+})
+
+describe('HostVisibilityToggles — interaction', () => {
+  it('calls toggle with showQuestion', async () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    await userEvent.click(screen.getByRole('switch', { name: 'Show question' }))
+    expect(mockToggle).toHaveBeenCalledWith('showQuestion')
+  })
+  it('calls toggle with showAnswers', async () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    await userEvent.click(screen.getByRole('switch', { name: 'Show answers' }))
+    expect(mockToggle).toHaveBeenCalledWith('showAnswers')
+  })
+  it('calls toggle with showMedia', async () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    await userEvent.click(screen.getByRole('switch', { name: 'Show media' }))
+    expect(mockToggle).toHaveBeenCalledWith('showMedia')
+  })
+  it('disables all switches while saving', () => {
+    vi.mocked(useGameVisibility).mockReturnValue({
+      visibility: { showQuestion: true, showAnswers: false, showMedia: true },
+      toggle: mockToggle,
+      saving: true,
+      error: null,
+    })
+    render(<HostVisibilityToggles game={GAME} />)
+    screen.getAllByRole('switch').forEach(sw => expect(sw).toBeDisabled())
+  })
+})
+
+describe('HostVisibilityToggles — error state', () => {
+  it('shows error message when error is set', () => {
+    vi.mocked(useGameVisibility).mockReturnValue({
+      visibility: { showQuestion: true, showAnswers: false, showMedia: true },
+      toggle: mockToggle,
+      saving: false,
+      error: 'Failed to save visibility',
+    })
+    render(<HostVisibilityToggles game={GAME} />)
+    expect(screen.getByText('Failed to save visibility')).toBeInTheDocument()
+  })
+  it('renders no error when error is null', () => {
+    render(<HostVisibilityToggles game={GAME} />)
+    expect(screen.queryByText(/failed/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/test/host/useGameVisibility.test.ts
+++ b/src/test/host/useGameVisibility.test.ts
@@ -1,0 +1,139 @@
+// @vitest-pool vmForks
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useGameVisibility } from '@/hooks/useGameVisibility'
+import type { Game } from '@/db'
+
+vi.mock('@/db', () => ({ db: { games: { update: vi.fn() } } }))
+vi.mock('@/transport', () => ({ transportManager: { send: vi.fn() } }))
+
+import { db } from '@/db'
+import { transportManager } from '@/transport'
+
+const BASE_GAME: Game = {
+  id: 'g1',
+  name: 'Test',
+  status: 'active',
+  transportMode: 'auto',
+  roomId: 'ABC',
+  passphrase: 'a-b-c-d',
+  scoringEnabled: true,
+  showQuestion: true,
+  showAnswers: false,
+  showMedia: true,
+  maxTeams: 0,
+  maxPerTeam: 0,
+  allowIndividual: true,
+  roundIds: [],
+  currentRoundIdx: 0,
+  currentQuestionIdx: 0,
+  buzzerLocked: false,
+  createdAt: 0,
+  updatedAt: 0,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(db.games.update).mockResolvedValue(1)
+})
+
+describe('useGameVisibility — initial state', () => {
+  it('initialises from game record', () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    expect(result.current.visibility).toEqual({
+      showQuestion: true,
+      showAnswers: false,
+      showMedia: true,
+    })
+  })
+  it('starts with saving=false and error=null', () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    expect(result.current.saving).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+})
+
+describe('useGameVisibility — toggle', () => {
+  it('flips the targeted key', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.visibility.showAnswers).toBe(true)
+  })
+  it('does not change other keys', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.visibility.showQuestion).toBe(true)
+    expect(result.current.visibility.showMedia).toBe(true)
+  })
+  it('persists full state to db.games.update', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(db.games.update).toHaveBeenCalledWith(
+      'g1',
+      expect.objectContaining({
+        showQuestion: true,
+        showAnswers: true,
+        showMedia: true,
+      })
+    )
+  })
+  it('emits VISIBILITY event via transportManager', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showMedia')
+    })
+    expect(transportManager.send).toHaveBeenCalledWith({
+      type: 'VISIBILITY',
+      showQuestion: true,
+      showAnswers: false,
+      showMedia: false,
+    })
+  })
+  it('resets saving to false after success', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.saving).toBe(false)
+  })
+})
+
+describe('useGameVisibility — rollback on error', () => {
+  beforeEach(() => {
+    vi.mocked(db.games.update).mockRejectedValue(new Error('DB write failed'))
+  })
+  it('rolls back optimistic update', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.visibility.showAnswers).toBe(false)
+  })
+  it('sets error message', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.error).toBe('DB write failed')
+  })
+  it('does not emit event', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(transportManager.send).not.toHaveBeenCalled()
+  })
+  it('resets saving to false', async () => {
+    const { result } = renderHook(() => useGameVisibility(BASE_GAME))
+    await act(async () => {
+      await result.current.toggle('showAnswers')
+    })
+    expect(result.current.saving).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Closes #9 

## What

Adds the host-side question panel for use during a live game. The host
always sees everything; visibility toggles control what players see.

## Changes

### New components — `src/components/host/`
- **`HostQuestionHeader`** — question title, type pill
  (`multiple_choice` / `true_false` / `open_ended`), and a colour-coded
  `GameQuestion.status` badge (pending / correct / incorrect / skipped)
- **`HostQuestionAnswers`** — per-type answer rendering: lettered option
  list with correct answer highlighted (multiple choice), True/False pill
  pair (true/false), expected answer block (open ended)
- **`HostQuestionMedia`** — renders `<img>`, `<audio>`, or `<video>`
  based on `question.mediaType`; returns null when media is absent
- **`HostVisibilityToggles`** — three toggle switches for
  `showQuestion / showAnswers / showMedia`; each toggle persists to DB
  and immediately emits a `VISIBILITY` event to all connected players
- **`HostQuestionPanel`** — composes the four components above into the
  full host view

### New hook — `src/hooks/`
- **`useGameVisibility`** — manages visibility state with optimistic
  updates and rollback on DB error

### Tests — `src/test/host/`
70 tests across 6 files covering all components and the hook.

## Acceptance criteria

- [x] Question title, type badge, and answer always visible to host
- [x] `multiple_choice`: all options rendered, correct highlighted
- [x] `true_false`: True/False rendered, correct highlighted
- [x] `open_ended`: expected answer text shown
- [x] Three visibility toggles mirror `game.showQuestion / showAnswers / showMedia`
- [x] Toggling persists to DB and emits `VISIBILITY` event immediately
- [x] Media rendered when `question.media` is set
- [x] `GameQuestion.status` shown as a badge

## Not included

`HostQuestionPanel` is built but not yet wired into `GameMaster.tsx` —
that's a follow-up so this PR stays reviewable in isolation.

## Testing

```bash
npm run typecheck   # 0 errors
npm test            # 272 passed
npm test -- src/test/host/   # 70 epic-9 tests in isolation
```