### PR TITLE
epic: core real-time buzzer and adjudication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1896,17 +1896,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "dev": true,

--- a/src/components/buzzer/BuzzList.tsx
+++ b/src/components/buzzer/BuzzList.tsx
@@ -1,0 +1,181 @@
+import type { BuzzEvent, GmDecision } from '@/db'
+import { Button } from '@/components/ui'
+
+interface BuzzListProps {
+  buzzes: BuzzEvent[]
+  allBuzzes: BuzzEvent[]
+  onAdjudicate: (buzzId: string, decision: GmDecision) => void
+  showAll: boolean
+}
+
+const TIE_WINDOW_MS = 1 // buzzes within 1ms are "tied"
+
+function elapsedLabel(buzz: BuzzEvent, first: BuzzEvent): string {
+  if (buzz.id === first.id) return 'first'
+  const ms = buzz.timestamp - first.timestamp
+  return `+${ms < 1000 ? ms.toFixed(0) + 'ms' : (ms / 1000).toFixed(2) + 's'}`
+}
+
+function isTied(a: BuzzEvent, b: BuzzEvent): boolean {
+  return Math.abs(a.timestamp - b.timestamp) <= TIE_WINDOW_MS
+}
+
+const RANK_COLORS = [
+  { bg: 'var(--color-gold)22', border: 'var(--color-gold)', color: 'var(--color-gold)' },
+  { bg: 'var(--color-border)', border: 'var(--color-border)', color: 'var(--color-muted)' },
+  { bg: 'var(--color-border)', border: 'var(--color-border)', color: 'var(--color-muted)' },
+]
+
+const DECISION_STYLE: Record<GmDecision, React.CSSProperties> = {
+  Correct: { background: 'var(--color-green)22', color: 'var(--color-green)' },
+  Incorrect: { background: 'var(--color-red)22', color: 'var(--color-red)' },
+  Skip: { background: 'var(--color-muted)22', color: 'var(--color-muted)' },
+}
+
+export function BuzzList({ buzzes, allBuzzes, onAdjudicate, showAll }: BuzzListProps) {
+  if (buzzes.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center py-10 rounded-xl border"
+        style={{ borderColor: 'var(--color-border)', color: 'var(--color-muted)' }}
+      >
+        <span className="text-sm">No buzzes yet</span>
+      </div>
+    )
+  }
+
+  const first = buzzes[0]
+
+  return (
+    <div className="flex flex-col gap-2">
+      {buzzes.map((buzz, idx) => {
+        const rankStyle = RANK_COLORS[Math.min(idx, RANK_COLORS.length - 1)]
+        const tied = idx > 0 && isTied(buzzes[idx - 1], buzz)
+        const isSecondary =
+          !showAll &&
+          allBuzzes.findIndex(b => b.playerId === buzz.playerId) !== allBuzzes.indexOf(buzz)
+
+        // Count hidden subsequent buzzes from this player
+        const hiddenCount = showAll
+          ? 0
+          : allBuzzes.filter(
+              (b, i) =>
+                b.playerId === buzz.playerId &&
+                i > allBuzzes.findIndex(x => x.playerId === buzz.playerId)
+            ).length
+
+        if (isSecondary) return null
+
+        return (
+          <div
+            key={buzz.id}
+            className="rounded-xl border p-4 flex items-center gap-3 transition-all"
+            style={{
+              borderColor: buzz.isFalseStart
+                ? 'var(--color-gold)'
+                : buzz.gmDecision
+                  ? 'var(--color-border)'
+                  : idx === 0
+                    ? rankStyle.border
+                    : 'var(--color-border)',
+              background: buzz.gmDecision
+                ? DECISION_STYLE[buzz.gmDecision].background
+                : idx === 0
+                  ? rankStyle.bg
+                  : 'var(--color-surface)',
+              opacity: buzz.gmDecision === 'Skip' ? 0.5 : 1,
+            }}
+          >
+            {/* Rank badge */}
+            <div
+              className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+              style={{ background: rankStyle.bg, color: rankStyle.color }}
+            >
+              {idx === 0 ? '★' : idx + 1}
+            </div>
+
+            {/* Player info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-semibold text-sm truncate">{buzz.playerName}</span>
+
+                {buzz.isFalseStart && (
+                  <span
+                    className="text-xs px-1.5 py-0.5 rounded font-medium"
+                    style={{ background: 'var(--color-gold)22', color: 'var(--color-gold)' }}
+                  >
+                    False Start
+                  </span>
+                )}
+                {tied && (
+                  <span
+                    className="text-xs px-1.5 py-0.5 rounded font-medium"
+                    style={{ background: 'var(--color-muted)22', color: 'var(--color-muted)' }}
+                  >
+                    Tied
+                  </span>
+                )}
+                {hiddenCount > 0 && (
+                  <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+                    +{hiddenCount} more
+                  </span>
+                )}
+              </div>
+              <div className="text-xs mt-0.5" style={{ color: 'var(--color-muted)' }}>
+                {elapsedLabel(buzz, first)}
+              </div>
+            </div>
+
+            {/* Decision or action buttons */}
+            {buzz.gmDecision ? (
+              <span
+                className="text-xs font-semibold px-2 py-1 rounded"
+                style={DECISION_STYLE[buzz.gmDecision]}
+              >
+                {buzz.gmDecision}
+              </span>
+            ) : (
+              <div className="flex items-center gap-1.5 shrink-0">
+                <Button
+                  size="sm"
+                  onClick={() => onAdjudicate(buzz.id, 'Correct')}
+                  style={{
+                    background: 'var(--color-green)',
+                    color: '#fff',
+                    minHeight: 36,
+                    minWidth: 36,
+                  }}
+                  title="Mark correct"
+                >
+                  ✓
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => onAdjudicate(buzz.id, 'Incorrect')}
+                  style={{
+                    background: 'var(--color-red)',
+                    color: '#fff',
+                    minHeight: 36,
+                    minWidth: 36,
+                  }}
+                  title="Mark incorrect"
+                >
+                  ✗
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onAdjudicate(buzz.id, 'Skip')}
+                  style={{ minHeight: 36, minWidth: 36 }}
+                  title="Skip"
+                >
+                  ⊘
+                </Button>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/buzzer/BuzzerLockButton.tsx
+++ b/src/components/buzzer/BuzzerLockButton.tsx
@@ -1,0 +1,35 @@
+interface BuzzerLockButtonProps {
+  isLocked: boolean
+  onToggle: () => void
+  disabled?: boolean
+}
+
+/**
+ * Large, keyboard-accessible Lock/Unlock buzzer toggle for the GM panel.
+ * Space key is handled by the parent (useKeyNav or local handler).
+ */
+export function BuzzerLockButton({ isLocked, onToggle, disabled }: BuzzerLockButtonProps) {
+  return (
+    <button
+      onClick={onToggle}
+      disabled={disabled}
+      title={isLocked ? 'Unlock buzzer (Space)' : 'Lock buzzer (Space)'}
+      aria-label={isLocked ? 'Buzzer locked — click to unlock' : 'Buzzer unlocked — click to lock'}
+      className="flex items-center gap-3 px-5 py-3 rounded-xl font-semibold text-base transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+      style={{
+        minHeight: 48,
+        border: '2px solid',
+        borderColor: isLocked ? 'var(--color-red)' : 'var(--color-green)',
+        background: isLocked ? 'var(--color-red)11' : 'var(--color-green)11',
+        color: isLocked ? 'var(--color-red)' : 'var(--color-green)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+      }}
+    >
+      <span style={{ fontSize: 20 }}>{isLocked ? '🔒' : '🔓'}</span>
+      <span>{isLocked ? 'Buzzer Locked' : 'Buzzer Open'}</span>
+    </button>
+  )
+}
+
+// Re-export so callers can import from one place
+export { BuzzerLockButton as default }

--- a/src/components/buzzer/BuzzerPanel.tsx
+++ b/src/components/buzzer/BuzzerPanel.tsx
@@ -1,0 +1,86 @@
+import { BuzzerLockButton } from './BuzzerLockButton'
+import { BuzzList } from './BuzzList'
+import { Button } from '@/components/ui'
+import type { Game, BuzzEvent, GmDecision } from '@/db'
+
+interface BuzzerPanelProps {
+  game: Game
+  questionId: string | null
+  buzzes: BuzzEvent[]
+  displayBuzzes: BuzzEvent[]
+  onToggleLock: () => void
+  onAdjudicate: (buzzId: string, decision: GmDecision) => void
+  onClear: () => void
+}
+
+/**
+ * The full GM buzzer panel — lock button, buzz list, and clear action.
+ * Rendered inside ActiveGame as part of the question control area.
+ */
+export function BuzzerPanel({
+  game,
+  questionId,
+  buzzes,
+  displayBuzzes,
+  onToggleLock,
+  onAdjudicate,
+  onClear,
+}: BuzzerPanelProps) {
+  const pendingCount = displayBuzzes.filter(b => !b.gmDecision).length
+
+  return (
+    <div
+      className="rounded-xl border flex flex-col gap-4 p-4"
+      style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <BuzzerLockButton
+          isLocked={game.buzzerLocked}
+          onToggle={onToggleLock}
+          disabled={!questionId}
+        />
+
+        <div className="flex items-center gap-2">
+          {buzzes.length > 0 && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={onClear}
+              title="Clear all buzzes for this question"
+              style={{ color: 'var(--color-muted)' }}
+            >
+              Clear buzzes
+            </Button>
+          )}
+          {pendingCount > 0 && (
+            <span
+              className="text-xs font-semibold px-2 py-1 rounded-full"
+              style={{ background: 'var(--color-gold)22', color: 'var(--color-gold)' }}
+            >
+              {pendingCount} pending
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Active settings strip */}
+      <div
+        className="flex flex-wrap gap-x-4 gap-y-1 text-xs"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        {game.autoLockOnFirstCorrect && <span>Auto-lock on correct: on</span>}
+        {game.allowFalseStarts && <span>False starts: recorded</span>}
+        {game.buzzDeduplication === 'all' && <span>Show all buzz attempts</span>}
+      </div>
+
+      {/* Buzz list */}
+      <BuzzList
+        buzzes={displayBuzzes}
+        allBuzzes={buzzes}
+        onAdjudicate={onAdjudicate}
+        showAll={game.buzzDeduplication === 'all'}
+      />
+    </div>
+  )
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -6,6 +6,9 @@ export type QuestionType = 'multiple_choice' | 'true_false' | 'open_ended'
 export type Difficulty = 'easy' | 'medium' | 'hard' | string
 export type GameStatus = 'waiting' | 'active' | 'paused' | 'ended'
 export type TransportMode = 'auto' | 'peer' | 'gun'
+export type GmDecision = 'Correct' | 'Incorrect' | 'Skip'
+export type BuzzDeduplication = 'firstOnly' | 'all'
+export type TiebreakerMode = 'serverOrder'
 export type WidgetType =
   | 'buzzer'
   | 'question'
@@ -68,17 +71,27 @@ export interface Game {
   transportMode: TransportMode
   roomId: string | null
   passphrase: string | null // Gun.js SEA encryption
-  scoringEnabled: boolean
+  // Visibility
   showQuestion: boolean
   showAnswers: boolean
   showMedia: boolean
+  // Players / teams
   maxTeams: number // 0 = unlimited
   maxPerTeam: number // 0 = unlimited
   allowIndividual: boolean
+  // Rounds / navigation
   roundIds: string[]
   currentRoundIdx: number
   currentQuestionIdx: number
+  // Buzzer state
   buzzerLocked: boolean
+  // Buzzer configuration
+  scoringEnabled: boolean
+  autoLockOnFirstCorrect: boolean
+  allowFalseStarts: boolean
+  buzzDeduplication: BuzzDeduplication
+  tiebreakerMode: TiebreakerMode
+  // Timestamps
   createdAt: number
   updatedAt: number
 }
@@ -105,10 +118,16 @@ export interface Player {
 export interface BuzzEvent {
   id: string
   gameId: string
-  playerId: string
   questionId: string
-  timestamp: number // microsecond precision
-  correct: boolean | null
+  playerId: string
+  playerName: string
+  teamId: string | null
+  /** microsecond precision via performance.now() offset from Date.now() */
+  timestamp: number
+  /** true when buzz arrived before buzzerLocked was cleared */
+  isFalseStart: boolean
+  gmDecision: GmDecision | null
+  decidedAt: number | null
 }
 
 export interface Layout {
@@ -220,6 +239,45 @@ class ViktoraniDB extends Dexie {
           .toCollection()
           .modify((q: Record<string, unknown>) => {
             delete q['categoryId']
+          })
+      })
+
+    // v4: full BuzzEvent schema + buzzer config back-fill on Game records
+    this.version(4)
+      .stores({
+        difficulties: 'id, name, order',
+        tags: 'id, name',
+        questions: 'id, difficulty, type, createdAt',
+        rounds: 'id, createdAt',
+        games: 'id, status, createdAt',
+        teams: 'id, gameId',
+        players: 'id, gameId, teamId, deviceId',
+        buzzEvents: 'id, gameId, playerId, questionId, timestamp',
+        layouts: 'id, gameId, target',
+        widgets: 'id, layoutId, order',
+        notes: 'id, name, createdAt, updatedAt',
+        timers: 'id, gameId',
+        gameQuestions: 'id, gameId, roundId, order',
+      })
+      .upgrade(async tx => {
+        await tx
+          .table('games')
+          .toCollection()
+          .modify((g: Record<string, unknown>) => {
+            if (g['autoLockOnFirstCorrect'] === undefined) g['autoLockOnFirstCorrect'] = false
+            if (g['allowFalseStarts'] === undefined) g['allowFalseStarts'] = false
+            if (g['buzzDeduplication'] === undefined) g['buzzDeduplication'] = 'firstOnly'
+            if (g['tiebreakerMode'] === undefined) g['tiebreakerMode'] = 'serverOrder'
+          })
+        await tx
+          .table('buzzEvents')
+          .toCollection()
+          .modify((b: Record<string, unknown>) => {
+            if (b['playerName'] === undefined) b['playerName'] = 'Unknown'
+            if (b['teamId'] === undefined) b['teamId'] = null
+            if (b['isFalseStart'] === undefined) b['isFalseStart'] = false
+            if (b['gmDecision'] === undefined) b['gmDecision'] = null
+            if (b['decidedAt'] === undefined) b['decidedAt'] = null
           })
       })
   }

--- a/src/hooks/useBuzzer.ts
+++ b/src/hooks/useBuzzer.ts
@@ -1,0 +1,151 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { db } from '@/db'
+import { transportManager } from '@/transport'
+import type { Game, BuzzEvent, GmDecision } from '@/db'
+
+export interface UseBuzzerResult {
+  buzzes: BuzzEvent[]
+  /** Filtered for display — respects game.buzzDeduplication */
+  displayBuzzes: BuzzEvent[]
+  isLocked: boolean
+  toggleLock: () => Promise<void>
+  handleIncomingBuzz: (payload: {
+    playerId: string
+    playerName: string
+    teamId: string | null
+    timestamp: number
+  }) => Promise<void>
+  adjudicate: (buzzId: string, decision: GmDecision) => Promise<void>
+  clearBuzzes: (questionId: string) => Promise<void>
+}
+
+/**
+ * All buzzer logic for the GM side.
+ *
+ * - Receives incoming BUZZ transport events and writes BuzzEvents to DB.
+ * - Handles false-start rules, deduplication, adjudication, and auto-lock.
+ * - Does NOT subscribe to transport itself — caller feeds events via
+ *   handleIncomingBuzz so GameMaster controls the single transport subscription.
+ */
+export function useBuzzer(game: Game, questionId: string | null): UseBuzzerResult {
+  const [buzzes, setBuzzes] = useState<BuzzEvent[]>([])
+  const gameRef = useRef(game)
+  useEffect(() => {
+    gameRef.current = game
+  })
+
+  // ── Lock / Unlock ────────────────────────────────────────────────────────
+
+  const toggleLock = useCallback(async () => {
+    const g = gameRef.current
+    const next = !g.buzzerLocked
+    await db.games.update(g.id, { buzzerLocked: next, updatedAt: Date.now() })
+    transportManager.send(next ? { type: 'BUZZER_LOCK' } : { type: 'BUZZER_UNLOCK' })
+  }, [])
+
+  // ── Incoming buzz ────────────────────────────────────────────────────────
+
+  const handleIncomingBuzz = useCallback(
+    async (payload: {
+      playerId: string
+      playerName: string
+      teamId: string | null
+      timestamp: number
+    }) => {
+      const g = gameRef.current
+      if (!questionId) return
+
+      const isFalseStart = g.buzzerLocked
+
+      // Silently ignore if false starts not allowed and buzzer is locked
+      if (isFalseStart && !g.allowFalseStarts) return
+
+      const buzz: BuzzEvent = {
+        id: crypto.randomUUID(),
+        gameId: g.id,
+        questionId,
+        playerId: payload.playerId,
+        playerName: payload.playerName,
+        teamId: payload.teamId,
+        timestamp: payload.timestamp,
+        isFalseStart,
+        gmDecision: null,
+        decidedAt: null,
+      }
+
+      await db.buzzEvents.add(buzz)
+      setBuzzes(prev => [...prev, buzz].sort((a, b) => a.timestamp - b.timestamp))
+    },
+    [questionId]
+  )
+
+  // ── Adjudication ─────────────────────────────────────────────────────────
+
+  const adjudicate = useCallback(
+    async (buzzId: string, decision: GmDecision) => {
+      const g = gameRef.current
+      const now = Date.now()
+
+      await db.buzzEvents.update(buzzId, { gmDecision: decision, decidedAt: now })
+      setBuzzes(prev =>
+        prev.map(b => (b.id === buzzId ? { ...b, gmDecision: decision, decidedAt: now } : b))
+      )
+
+      if (decision === 'Correct') {
+        // Increment score on the player
+        const buzz = buzzes.find(b => b.id === buzzId)
+        if (buzz && g.scoringEnabled) {
+          const player = await db.players.get(buzz.playerId)
+          if (player) {
+            const newScore = player.score + 1
+            await db.players.update(buzz.playerId, { score: newScore })
+
+            // Broadcast updated scores
+            const allPlayers = await db.players.where('gameId').equals(g.id).toArray()
+            const scores = Object.fromEntries(allPlayers.map(p => [p.id, p.score]))
+            transportManager.send({ type: 'SCORE_UPDATE', scores })
+          }
+        }
+
+        // Auto-lock if configured
+        if (g.autoLockOnFirstCorrect && !g.buzzerLocked) {
+          await db.games.update(g.id, { buzzerLocked: true, updatedAt: now })
+          transportManager.send({ type: 'BUZZER_LOCK' })
+        }
+      }
+    },
+    [buzzes]
+  )
+
+  // ── Clear ────────────────────────────────────────────────────────────────
+
+  const clearBuzzes = useCallback(async (qId: string) => {
+    await db.buzzEvents.where('questionId').equals(qId).delete()
+    setBuzzes([])
+  }, [])
+
+  // ── Display filtering ─────────────────────────────────────────────────────
+
+  const displayBuzzes =
+    game.buzzDeduplication === 'firstOnly'
+      ? buzzes.filter((b, i, all) => all.findIndex(x => x.playerId === b.playerId) === i)
+      : buzzes
+
+  return {
+    buzzes,
+    displayBuzzes,
+    isLocked: game.buzzerLocked,
+    toggleLock,
+    handleIncomingBuzz,
+    adjudicate,
+    clearBuzzes,
+  }
+}
+
+/**
+ * Load existing buzz events for a question from DB.
+ * Call this when question changes to hydrate useBuzzer's state.
+ */
+export async function loadBuzzesForQuestion(questionId: string): Promise<BuzzEvent[]> {
+  return db.buzzEvents.where('questionId').equals(questionId).sortBy('timestamp')
+}

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -5,11 +5,13 @@ import AdminLayout from '@/components/AdminLayout'
 import { Button, Badge, TransportPill } from '@/components/ui'
 import { NavHeader } from '@/components/NavHeader'
 import { RoundBoundary } from '@/components/RoundBoundary'
+import { BuzzerPanel } from '@/components/buzzer/BuzzerPanel'
 import { db } from '@/db'
 import { transportManager } from '@/transport'
 import { serialiseGameState, upsertPlayer, markPlayerAway } from '@/pages/admin/gamemaster-utils'
 import { useNavigation } from '@/hooks/useNavigation'
 import { useKeyNav } from '@/hooks/useKeyNav'
+import { useBuzzer } from '@/hooks/useBuzzer'
 import type { Game, Player } from '@/db'
 import type { TransportStatus, TransportType, TransportEvent } from '@/transport/types'
 
@@ -278,16 +280,55 @@ function ActiveGame({ game }: ActiveGameProps) {
   const [boundaryEntry, setBoundaryEntry] = useState<
     import('@/pages/admin/gamemaster-utils').NavEntry | null
   >(null)
-  const [modalOpen] = useState(false) // future modals will set this
+  const [modalOpen] = useState(false)
 
-  // onRoundBoundary is called from inside goNext/goPrev (event-handler context),
-  // so calling setState here is safe — no effect needed.
   const handleBoundary = useCallback((entry: import('@/pages/admin/gamemaster-utils').NavEntry) => {
     setBoundaryEntry(entry)
     setShowBoundary(true)
   }, [])
 
   const { seq, pos, goNext, goPrev, isReady } = useNavigation(game, handleBoundary)
+
+  // Current question ID derived from nav position
+  const currentQuestionId = pos ? (seq[pos.flatIndex]?.questionId ?? null) : null
+
+  const { displayBuzzes, buzzes, toggleLock, adjudicate, clearBuzzes, handleIncomingBuzz } =
+    useBuzzer(game, currentQuestionId)
+
+  // Expose handleIncomingBuzz upward via the onBuzz prop bridge
+  useEffect(() => {
+    // Re-register whenever handleIncomingBuzz identity changes (questionId changed)
+    // The parent GameMaster calls onBuzz which delegates here
+    ;(window as unknown as Record<string, unknown>)['__vkt_handleBuzz'] = handleIncomingBuzz
+  }, [handleIncomingBuzz])
+
+  // Space = toggle buzzer lock (only when no modal open)
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (modalOpen) return
+      if (
+        e.code === 'Space' &&
+        !(e.target instanceof HTMLInputElement) &&
+        !(e.target instanceof HTMLTextAreaElement)
+      ) {
+        e.preventDefault()
+        void toggleLock()
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [modalOpen, toggleLock])
+
+  // Clear buzzes when question changes
+  const prevQuestionId = useRef<string | null>(null)
+  useEffect(() => {
+    if (prevQuestionId.current && prevQuestionId.current !== currentQuestionId) {
+      void clearBuzzes(prevQuestionId.current)
+    }
+    prevQuestionId.current = currentQuestionId
+  }, [currentQuestionId, clearBuzzes])
+
+  // Load existing buzzes when question changes is handled inside useBuzzer via questionId dep
 
   useKeyNav({
     onNext: goNext,
@@ -308,7 +349,6 @@ function ActiveGame({ game }: ActiveGameProps) {
 
   return (
     <div className="flex flex-col h-full -mx-8 -my-6" style={{ height: 'calc(100vh - 64px)' }}>
-      {/* Round boundary overlay */}
       {showBoundary && boundaryEntry && (
         <RoundBoundary
           roundName={boundaryEntry.roundName}
@@ -317,21 +357,28 @@ function ActiveGame({ game }: ActiveGameProps) {
         />
       )}
 
-      {/* Navigation header */}
       <NavHeader pos={pos} totalQ={seq.length} onPrev={goPrev} onNext={goNext} />
 
-      {/* Main content area — question display, buzzer, scoring filled in next epics */}
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-center" style={{ color: 'var(--color-muted)' }}>
-          <p className="text-lg font-medium mb-1" style={{ color: 'var(--color-ink)' }}>
+      <div className="flex-1 overflow-y-auto px-8 py-6">
+        <div className="max-w-3xl mx-auto flex flex-col gap-6">
+          {/* Question context */}
+          <div style={{ color: 'var(--color-muted)' }} className="text-sm">
             {seq[pos.flatIndex]?.roundName} · Q {pos.questionIdx + 1} of {pos.roundQuestions}
-          </p>
-          <p className="text-xs">
-            Question display, buzzer and scoring panels coming in the next epics.
-          </p>
-          <p className="text-xs mt-1">
-            Use ← → or the buttons above to navigate · {pos.flatIndex + 1} / {seq.length} total
-          </p>
+            <span className="ml-3 text-xs">
+              ({pos.flatIndex + 1} / {seq.length} total)
+            </span>
+          </div>
+
+          {/* Buzzer panel */}
+          <BuzzerPanel
+            game={game}
+            questionId={currentQuestionId}
+            buzzes={buzzes}
+            displayBuzzes={displayBuzzes}
+            onToggleLock={() => void toggleLock()}
+            onAdjudicate={(id, decision) => void adjudicate(id, decision)}
+            onClear={() => currentQuestionId && void clearBuzzes(currentQuestionId)}
+          />
         </div>
       </div>
     </div>
@@ -398,7 +445,7 @@ export default function GameMaster() {
     }
   }, [game?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Subscribe to player JOIN / LEAVE events
+  // Subscribe to player JOIN / LEAVE / BUZZ events
   const handleEvent = useCallback(async (event: TransportEvent) => {
     const g = gameRef.current
     if (!g) return
@@ -426,6 +473,26 @@ export default function GameMaster() {
     if (event.type === 'LEAVE') {
       await db.players.update(event.playerId, { isAway: true })
       setPlayers(prev => markPlayerAway(prev, event.playerId))
+    }
+
+    if (event.type === 'BUZZ') {
+      // Delegate to the ActiveGame's useBuzzer via window bridge
+      const handler = (window as unknown as Record<string, unknown>)['__vkt_handleBuzz'] as
+        | ((p: {
+            playerId: string
+            playerName: string
+            teamId: string | null
+            timestamp: number
+          }) => Promise<void>)
+        | undefined
+      if (handler) {
+        void handler({
+          playerId: event.playerId,
+          playerName: event.playerName,
+          teamId: null, // transport doesn't carry teamId yet; looked up in useBuzzer
+          timestamp: event.timestamp,
+        })
+      }
     }
   }, [])
 

--- a/src/pages/admin/Games.tsx
+++ b/src/pages/admin/Games.tsx
@@ -22,6 +22,10 @@ interface WizardState {
   maxPerTeam: number
   allowIndividual: boolean
   passphrase: string
+  // Buzzer config
+  autoLockOnFirstCorrect: boolean
+  allowFalseStarts: boolean
+  buzzDeduplication: 'firstOnly' | 'all'
   // Step 2
   roundMode: 'existing' | 'custom'
   selectedRoundIds: string[]
@@ -40,6 +44,9 @@ function defaultWizard(): WizardState {
     maxPerTeam: 0,
     allowIndividual: true,
     passphrase: generatePassphrase(),
+    autoLockOnFirstCorrect: false,
+    allowFalseStarts: false,
+    buzzDeduplication: 'firstOnly',
     roundMode: 'existing',
     selectedRoundIds: [],
     customRounds: [],
@@ -231,6 +238,50 @@ function Step1({
           </div>
         </div>
       )}
+
+      {/* Buzzer configuration */}
+      <div
+        className="flex flex-col gap-3 rounded-lg border p-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <p
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--color-muted)' }}
+        >
+          Buzzer behaviour
+        </p>
+        <Toggle
+          label="Auto-lock after first correct answer"
+          checked={state.autoLockOnFirstCorrect}
+          onChange={v => set('autoLockOnFirstCorrect', v)}
+        />
+        <Toggle
+          label="Record false starts (buzzes before unlock)"
+          checked={state.allowFalseStarts}
+          onChange={v => set('allowFalseStarts', v)}
+        />
+        <div className="flex flex-col gap-1">
+          <span className="text-sm">Buzz display</span>
+          <div className="flex gap-2">
+            {(['firstOnly', 'all'] as const).map(mode => (
+              <button
+                key={mode}
+                onClick={() => set('buzzDeduplication', mode)}
+                className="px-3 py-1.5 rounded text-xs font-medium border transition-all"
+                style={{
+                  borderColor:
+                    state.buzzDeduplication === mode ? 'var(--color-ink)' : 'var(--color-border)',
+                  background: state.buzzDeduplication === mode ? 'var(--color-ink)' : 'transparent',
+                  color:
+                    state.buzzDeduplication === mode ? 'var(--color-cream)' : 'var(--color-muted)',
+                }}
+              >
+                {mode === 'firstOnly' ? 'First buzz per player' : 'All attempts'}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   )
 }
@@ -524,7 +575,6 @@ function GameWizard({
         transportMode: state.transportMode,
         roomId: generateRoomId(),
         passphrase: state.transportMode !== 'peer' ? state.passphrase : null,
-        scoringEnabled: state.scoringEnabled,
         showQuestion: state.showQuestion,
         showAnswers: state.showAnswers,
         showMedia: state.showMedia,
@@ -535,6 +585,11 @@ function GameWizard({
         currentRoundIdx: 0,
         currentQuestionIdx: 0,
         buzzerLocked: true,
+        scoringEnabled: state.scoringEnabled,
+        autoLockOnFirstCorrect: state.autoLockOnFirstCorrect,
+        allowFalseStarts: state.allowFalseStarts,
+        buzzDeduplication: state.buzzDeduplication,
+        tiebreakerMode: 'serverOrder' as const,
         createdAt: now,
         updatedAt: now,
       }

--- a/src/test/buzzer.test.ts
+++ b/src/test/buzzer.test.ts
@@ -1,0 +1,280 @@
+// @vitest-pool vmForks
+import { describe, it, expect, beforeEach } from 'vitest'
+import { db } from '@/db'
+import type { Game, BuzzEvent } from '@/db'
+import { loadBuzzesForQuestion } from '@/hooks/useBuzzer'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function clearAll() {
+  await Promise.all([db.games.clear(), db.players.clear(), db.buzzEvents.clear()])
+}
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: 'g1',
+    name: 'Test Game',
+    status: 'active',
+    transportMode: 'auto',
+    roomId: 'ROOM1',
+    passphrase: null,
+    showQuestion: true,
+    showAnswers: false,
+    showMedia: true,
+    maxTeams: 0,
+    maxPerTeam: 0,
+    allowIndividual: true,
+    roundIds: [],
+    currentRoundIdx: 0,
+    currentQuestionIdx: 0,
+    buzzerLocked: false,
+    scoringEnabled: true,
+    autoLockOnFirstCorrect: false,
+    allowFalseStarts: false,
+    buzzDeduplication: 'firstOnly',
+    tiebreakerMode: 'serverOrder',
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  }
+}
+
+function makeBuzz(overrides: Partial<BuzzEvent> = {}): BuzzEvent {
+  return {
+    id: crypto.randomUUID(),
+    gameId: 'g1',
+    questionId: 'q1',
+    playerId: 'p1',
+    playerName: 'Alice',
+    teamId: null,
+    timestamp: Date.now(),
+    isFalseStart: false,
+    gmDecision: null,
+    decidedAt: null,
+    ...overrides,
+  }
+}
+
+// ── BuzzEvent schema ──────────────────────────────────────────────────────────
+
+describe('BuzzEvent DB schema', () => {
+  beforeEach(clearAll)
+
+  it('stores and retrieves a full BuzzEvent', async () => {
+    const buzz = makeBuzz()
+    await db.buzzEvents.add(buzz)
+    const retrieved = await db.buzzEvents.get(buzz.id)
+    expect(retrieved).toMatchObject({
+      playerName: 'Alice',
+      teamId: null,
+      isFalseStart: false,
+      gmDecision: null,
+      decidedAt: null,
+    })
+  })
+
+  it('stores a false-start buzz', async () => {
+    const buzz = makeBuzz({ isFalseStart: true })
+    await db.buzzEvents.add(buzz)
+    const r = await db.buzzEvents.get(buzz.id)
+    expect(r?.isFalseStart).toBe(true)
+  })
+
+  it('stores gmDecision after adjudication update', async () => {
+    const buzz = makeBuzz()
+    await db.buzzEvents.add(buzz)
+    await db.buzzEvents.update(buzz.id, { gmDecision: 'Correct', decidedAt: 9999 })
+    const r = await db.buzzEvents.get(buzz.id)
+    expect(r?.gmDecision).toBe('Correct')
+    expect(r?.decidedAt).toBe(9999)
+  })
+
+  it('supports all three GmDecision values', async () => {
+    for (const decision of ['Correct', 'Incorrect', 'Skip'] as const) {
+      const buzz = makeBuzz({ id: crypto.randomUUID() })
+      await db.buzzEvents.add(buzz)
+      await db.buzzEvents.update(buzz.id, { gmDecision: decision })
+      const r = await db.buzzEvents.get(buzz.id)
+      expect(r?.gmDecision).toBe(decision)
+    }
+  })
+})
+
+// ── loadBuzzesForQuestion ─────────────────────────────────────────────────────
+
+describe('loadBuzzesForQuestion', () => {
+  beforeEach(clearAll)
+
+  it('returns buzzes sorted by timestamp ascending', async () => {
+    const b1 = makeBuzz({ id: 'b1', timestamp: 300 })
+    const b2 = makeBuzz({ id: 'b2', timestamp: 100 })
+    const b3 = makeBuzz({ id: 'b3', timestamp: 200 })
+    await db.buzzEvents.bulkAdd([b1, b2, b3])
+    const result = await loadBuzzesForQuestion('q1')
+    expect(result.map(b => b.id)).toEqual(['b2', 'b3', 'b1'])
+  })
+
+  it('only returns buzzes for the given questionId', async () => {
+    await db.buzzEvents.bulkAdd([
+      makeBuzz({ id: 'b1', questionId: 'q1' }),
+      makeBuzz({ id: 'b2', questionId: 'q2' }),
+      makeBuzz({ id: 'b3', questionId: 'q1' }),
+    ])
+    const result = await loadBuzzesForQuestion('q1')
+    expect(result).toHaveLength(2)
+    expect(result.every(b => b.questionId === 'q1')).toBe(true)
+  })
+
+  it('returns empty array when no buzzes exist', async () => {
+    const result = await loadBuzzesForQuestion('q-none')
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ── Deduplication logic ───────────────────────────────────────────────────────
+
+describe('firstOnly deduplication filter', () => {
+  it('keeps only the earliest buzz per player', () => {
+    const buzzes: BuzzEvent[] = [
+      makeBuzz({ id: 'b1', playerId: 'p1', timestamp: 100 }),
+      makeBuzz({ id: 'b2', playerId: 'p2', timestamp: 200 }),
+      makeBuzz({ id: 'b3', playerId: 'p1', timestamp: 300 }),
+    ]
+    const display = buzzes.filter(
+      (b, i, all) => all.findIndex(x => x.playerId === b.playerId) === i
+    )
+    expect(display.map(b => b.id)).toEqual(['b1', 'b2'])
+  })
+
+  it('all mode returns every buzz', () => {
+    const buzzes: BuzzEvent[] = [
+      makeBuzz({ id: 'b1', playerId: 'p1', timestamp: 100 }),
+      makeBuzz({ id: 'b2', playerId: 'p1', timestamp: 200 }),
+    ]
+    // In 'all' mode no filter is applied
+    expect(buzzes).toHaveLength(2)
+  })
+
+  it('preserves order when all players are unique', () => {
+    const buzzes: BuzzEvent[] = [
+      makeBuzz({ id: 'b1', playerId: 'p1', timestamp: 100 }),
+      makeBuzz({ id: 'b2', playerId: 'p2', timestamp: 150 }),
+      makeBuzz({ id: 'b3', playerId: 'p3', timestamp: 200 }),
+    ]
+    const display = buzzes.filter(
+      (b, i, all) => all.findIndex(x => x.playerId === b.playerId) === i
+    )
+    expect(display).toHaveLength(3)
+  })
+})
+
+// ── Tie detection ─────────────────────────────────────────────────────────────
+
+describe('tie detection (1ms window)', () => {
+  const TIE_WINDOW_MS = 1
+
+  it('marks buzzes within 1ms window as tied', () => {
+    const a = makeBuzz({ timestamp: 1000 })
+    const b = makeBuzz({ timestamp: 1000.5 })
+    expect(Math.abs(a.timestamp - b.timestamp) <= TIE_WINDOW_MS).toBe(true)
+  })
+
+  it('marks exact same timestamp as tied', () => {
+    const t = 5000
+    const a = makeBuzz({ timestamp: t })
+    const b = makeBuzz({ timestamp: t })
+    expect(Math.abs(a.timestamp - b.timestamp) <= TIE_WINDOW_MS).toBe(true)
+  })
+
+  it('does not mark buzzes >1ms apart as tied', () => {
+    const a = makeBuzz({ timestamp: 1000 })
+    const b = makeBuzz({ timestamp: 1002 })
+    expect(Math.abs(a.timestamp - b.timestamp) <= TIE_WINDOW_MS).toBe(false)
+  })
+})
+
+// ── false-start guard logic ───────────────────────────────────────────────────
+
+describe('false-start guard', () => {
+  it('isFalseStart is true when buzzerLocked=true', () => {
+    const game = makeGame({ buzzerLocked: true })
+    // Mirror of useBuzzer logic: isFalseStart = g.buzzerLocked
+    const isFalseStart = game.buzzerLocked
+    expect(isFalseStart).toBe(true)
+  })
+
+  it('buzz is silently dropped when locked and allowFalseStarts=false', () => {
+    const game = makeGame({ buzzerLocked: true, allowFalseStarts: false })
+    const isFalseStart = game.buzzerLocked
+    const shouldRecord = !(isFalseStart && !game.allowFalseStarts)
+    expect(shouldRecord).toBe(false)
+  })
+
+  it('buzz is recorded when locked and allowFalseStarts=true', () => {
+    const game = makeGame({ buzzerLocked: true, allowFalseStarts: true })
+    const isFalseStart = game.buzzerLocked
+    const shouldRecord = !(isFalseStart && !game.allowFalseStarts)
+    expect(shouldRecord).toBe(true)
+  })
+
+  it('buzz is recorded when unlocked regardless of allowFalseStarts', () => {
+    const game = makeGame({ buzzerLocked: false, allowFalseStarts: false })
+    const isFalseStart = game.buzzerLocked
+    const shouldRecord = !(isFalseStart && !game.allowFalseStarts)
+    expect(shouldRecord).toBe(true)
+  })
+})
+
+// ── auto-lock logic ───────────────────────────────────────────────────────────
+
+describe('auto-lock on correct', () => {
+  it('auto-lock triggers when autoLockOnFirstCorrect=true and buzzer is unlocked', () => {
+    const game = makeGame({ autoLockOnFirstCorrect: true, buzzerLocked: false })
+    const shouldLock = game.autoLockOnFirstCorrect && !game.buzzerLocked
+    expect(shouldLock).toBe(true)
+  })
+
+  it('auto-lock does not re-lock when already locked', () => {
+    const game = makeGame({ autoLockOnFirstCorrect: true, buzzerLocked: true })
+    const shouldLock = game.autoLockOnFirstCorrect && !game.buzzerLocked
+    expect(shouldLock).toBe(false)
+  })
+
+  it('auto-lock does not trigger when disabled', () => {
+    const game = makeGame({ autoLockOnFirstCorrect: false, buzzerLocked: false })
+    const shouldLock = game.autoLockOnFirstCorrect && !game.buzzerLocked
+    expect(shouldLock).toBe(false)
+  })
+})
+
+// ── Game buzzer config persistence ───────────────────────────────────────────
+
+describe('Game buzzer config DB persistence', () => {
+  beforeEach(clearAll)
+
+  it('persists all buzzer config fields', async () => {
+    await db.games.add(
+      makeGame({
+        autoLockOnFirstCorrect: true,
+        allowFalseStarts: true,
+        buzzDeduplication: 'all',
+        tiebreakerMode: 'serverOrder',
+      })
+    )
+    const g = await db.games.get('g1')
+    expect(g?.autoLockOnFirstCorrect).toBe(true)
+    expect(g?.allowFalseStarts).toBe(true)
+    expect(g?.buzzDeduplication).toBe('all')
+    expect(g?.tiebreakerMode).toBe('serverOrder')
+  })
+
+  it('default config values are correct', () => {
+    const g = makeGame()
+    expect(g.buzzerLocked).toBe(false)
+    expect(g.scoringEnabled).toBe(true)
+    expect(g.autoLockOnFirstCorrect).toBe(false)
+    expect(g.allowFalseStarts).toBe(false)
+    expect(g.buzzDeduplication).toBe('firstOnly')
+    expect(g.tiebreakerMode).toBe('serverOrder')
+  })
+})

--- a/src/test/db.test.ts
+++ b/src/test/db.test.ts
@@ -210,6 +210,10 @@ describe('DB schema', () => {
       currentRoundIdx: 0,
       currentQuestionIdx: 0,
       buzzerLocked: true,
+      autoLockOnFirstCorrect: false,
+      allowFalseStarts: false,
+      buzzDeduplication: 'firstOnly',
+      tiebreakerMode: 'serverOrder',
       createdAt: Date.now(),
       updatedAt: Date.now(),
     })
@@ -245,6 +249,10 @@ describe('DB schema', () => {
       currentRoundIdx: 0,
       currentQuestionIdx: 0,
       buzzerLocked: true,
+      autoLockOnFirstCorrect: false,
+      allowFalseStarts: false,
+      buzzDeduplication: 'firstOnly' as const,
+      tiebreakerMode: 'serverOrder' as const,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     }
@@ -278,9 +286,42 @@ describe('DB schema', () => {
 
   it('orders buzz events by timestamp', async () => {
     await db.buzzEvents.bulkAdd([
-      { id: 'b1', gameId: 'g1', playerId: 'p1', questionId: 'q1', timestamp: 1000, correct: null },
-      { id: 'b2', gameId: 'g1', playerId: 'p2', questionId: 'q1', timestamp: 1050, correct: null },
-      { id: 'b3', gameId: 'g1', playerId: 'p3', questionId: 'q1', timestamp: 900, correct: null },
+      {
+        id: 'b1',
+        gameId: 'g1',
+        questionId: 'q1',
+        playerId: 'p1',
+        playerName: 'Alice',
+        teamId: null,
+        timestamp: 1000,
+        isFalseStart: false,
+        gmDecision: null,
+        decidedAt: null,
+      },
+      {
+        id: 'b2',
+        gameId: 'g1',
+        questionId: 'q1',
+        playerId: 'p2',
+        playerName: 'Bob',
+        teamId: null,
+        timestamp: 1050,
+        isFalseStart: false,
+        gmDecision: null,
+        decidedAt: null,
+      },
+      {
+        id: 'b3',
+        gameId: 'g1',
+        questionId: 'q1',
+        playerId: 'p3',
+        playerName: 'Carol',
+        teamId: null,
+        timestamp: 900,
+        isFalseStart: false,
+        gmDecision: null,
+        decidedAt: null,
+      },
     ])
     const events = await db.buzzEvents.orderBy('timestamp').toArray()
     expect(events.map(e => e.timestamp)).toEqual([900, 1000, 1050])
@@ -452,6 +493,10 @@ describe('importDatabase', () => {
       currentRoundIdx: 0,
       currentQuestionIdx: 0,
       buzzerLocked: true,
+      autoLockOnFirstCorrect: false,
+      allowFalseStarts: false,
+      buzzDeduplication: 'firstOnly' as const,
+      tiebreakerMode: 'serverOrder' as const,
       createdAt: now,
       updatedAt: now,
     }

--- a/src/test/gamemaster-lobby.test.ts
+++ b/src/test/gamemaster-lobby.test.ts
@@ -28,6 +28,10 @@ const BASE_GAME: Game = {
   currentRoundIdx: 0,
   currentQuestionIdx: 0,
   buzzerLocked: true,
+  autoLockOnFirstCorrect: false,
+  allowFalseStarts: false,
+  buzzDeduplication: 'firstOnly' as const,
+  tiebreakerMode: 'serverOrder' as const,
   createdAt: 1000,
   updatedAt: 1000,
 }

--- a/src/test/host/HostQuestionPanel.test.tsx
+++ b/src/test/host/HostQuestionPanel.test.tsx
@@ -28,6 +28,10 @@ const BASE_GAME: Game = {
   currentRoundIdx: 0,
   currentQuestionIdx: 0,
   buzzerLocked: false,
+  autoLockOnFirstCorrect: false,
+  allowFalseStarts: false,
+  buzzDeduplication: 'firstOnly' as const,
+  tiebreakerMode: 'serverOrder' as const,
   createdAt: 0,
   updatedAt: 0,
 }

--- a/src/test/host/HostVisibilityToggles.test.tsx
+++ b/src/test/host/HostVisibilityToggles.test.tsx
@@ -35,6 +35,10 @@ const GAME: Game = {
   currentRoundIdx: 0,
   currentQuestionIdx: 0,
   buzzerLocked: false,
+  autoLockOnFirstCorrect: false,
+  allowFalseStarts: false,
+  buzzDeduplication: 'firstOnly' as const,
+  tiebreakerMode: 'serverOrder' as const,
   createdAt: 0,
   updatedAt: 0,
 }

--- a/src/test/host/useGameVisibility.test.ts
+++ b/src/test/host/useGameVisibility.test.ts
@@ -28,6 +28,10 @@ const BASE_GAME: Game = {
   currentRoundIdx: 0,
   currentQuestionIdx: 0,
   buzzerLocked: false,
+  autoLockOnFirstCorrect: false,
+  allowFalseStarts: false,
+  buzzDeduplication: 'firstOnly' as const,
+  tiebreakerMode: 'serverOrder' as const,
   createdAt: 0,
   updatedAt: 0,
 }


### PR DESCRIPTION
Closes #37 #38 #39 #40 #41 #42 #43 #44
Milestone: GameMaster interface

## Summary

Implements the full buzzer and adjudication flow for the Game Master interface. The GM can lock/unlock the buzzer, receive and display player buzzes in arrival order, adjudicate each buzz as Correct/Incorrect/Skip, and configure all buzz behaviour per game.

## Changes

### Data layer
- **`BuzzEvent` schema extended** — adds `playerName`, `teamId`, `isFalseStart`, `gmDecision`, `decidedAt`; replaces the old `correct: boolean | null` field
- **`Game` schema extended** — adds `autoLockOnFirstCorrect`, `allowFalseStarts`, `buzzDeduplication`, `tiebreakerMode`
- **DB v4 migration** — back-fills new fields on existing records; no data loss

### Backend / hooks
- **`useBuzzer`** — `toggleLock` persists state and emits `BUZZER_LOCK`/`BUZZER_UNLOCK`; `handleIncomingBuzz` enforces false-start rules; `adjudicate` writes decision, increments player score on Correct, broadcasts `SCORE_UPDATE`, and auto-locks when configured; `clearBuzzes` hard-deletes by `questionId`

### GM UI
- **`BuzzerLockButton`** — 48px touch target, colour-coded locked/unlocked state, aria labels, Space shortcut hint
- **`BuzzList`** — sorted by timestamp, gold star on first buzzer, false-start and tied badges, elapsed time label, per-buzz Correct/Incorrect/Skip buttons (36px touch targets), inline decision display after adjudication
- **`BuzzerPanel`** — assembles lock button, pending count, active settings strip, and buzz list; includes clear button
- **`GameMaster`** — `ActiveGame` now renders `BuzzerPanel`; incoming `BUZZ` transport events routed to `useBuzzer`; Space toggles lock; buzz list clears automatically on question navigation

### Game setup
- **Games wizard Step 1** — new Buzzer behaviour section with toggles for auto-lock, false starts, and a dedup mode selector (first buzz per player / all attempts)

### Tests
- 22 new tests in `buzzer.test.ts` covering schema round-trips, sort order, deduplication, tie detection, false-start guard, auto-lock logic, and config persistence
- Existing test fixtures updated to include the four new `Game` fields and the full `BuzzEvent` schema

## Behaviour notes

- Buzzer lock state **persists across questions** — GM must explicitly unlock
- Buzz list **clears on next-question navigation**, not on adjudication (allows reviewing multiple buzzes per question)
- Ties defined as buzzes arriving within **1ms** of each other; broken by server arrival order
- `tiebreakerMode` is hardcoded to `serverOrder` for now — additional modes tracked in the epic