### PR TITLE
epic(docs): enhance project documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Publish API Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'typedoc.json'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Generate API docs
+        run: npm run docs
+
+      - name: Deploy to gh-pages (api/ subdirectory)
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/api
+          destination_dir: api
+          keep_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,7 @@ coverage/
 .DS_Store
 Thumbs.db
 
-# Scripts (added manually with git add --force)
+# Scripts and stuff
+archives/
+deploy/
 scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,32 @@
-# Logs
-logs
-*.log
-npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
+# Dependencies
+node_modules/
 
-node_modules
-dist
-dist-ssr
-*.local
+# Build output
+dist/
 
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
+# Generated API docs (built by npm run docs / docs.yml CI)
+docs/api/
+
+# Coverage
+coverage/
+
+# Local env
+.env
+.env.local
+.env.*.local
+
+# Editor
+.vscode/
+.idea/
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
 
-archives
-scripts
-coverage
-deploy
+# OS
+.DS_Store
+Thumbs.db
+
+# Scripts (added manually with git add --force)
+scripts/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Bar trivia PWA with WebRTC multiplayer, Reveal.js slides, and buzzer gameplay.
 No backend — runs entirely in the browser.
 
 **Live:** https://morbeo.github.io/viktorani/
+**API docs:** [![API Docs](https://img.shields.io/badge/docs-API-blue)](https://morbeo.github.io/viktorani/api/)
 
 ---
 
@@ -11,6 +12,7 @@ No backend — runs entirely in the browser.
 
 - [Tech stack](#tech-stack)
 - [Getting started](#getting-started)
+- [Documentation](#documentation)
 - [Project structure](#project-structure)
 - [Multiplayer](#multiplayer)
 - [Data storage](#data-storage)
@@ -51,6 +53,7 @@ npm run dev
 | ----------------------- | ---------------------------------------------- |
 | `npm run dev`           | Start dev server at `localhost:5173`           |
 | `npm run build`         | Type-check + production build → `dist/`        |
+| `npm run docs`          | Generate API docs → `docs/api/` (gitignored)   |
 | `npm run lint`          | ESLint across all `*.ts` / `*.tsx` files       |
 | `npm run typecheck`     | Type-check app and test files (both tsconfigs) |
 | `npm run test`          | Run unit tests once via Vitest                 |
@@ -62,6 +65,24 @@ npm run dev
 | `npm run release`       | Interactive release: choose version, tag, push |
 | `npm run release:patch` | Non-interactive patch bump                     |
 | `npm run release:minor` | Non-interactive minor bump                     |
+
+---
+
+## Documentation
+
+| Document | Description |
+| -------- | ----------- |
+| [Host guide](docs/user-guide/host.md) | Setting up and running a trivia night |
+| [Player guide](docs/user-guide/player.md) | Joining a game and buzzing in |
+| [API docs](https://morbeo.github.io/viktorani/api/) | Generated TypeDoc — transport, DB, hooks |
+| [Architecture decisions](docs/adr/) | ADRs for all major technical decisions |
+
+To generate API docs locally:
+
+```bash
+npm run docs
+# Output: docs/api/ (gitignored — generated at build time)
+```
 
 ---
 
@@ -104,6 +125,10 @@ src/
 │   ├── buzzer.test.ts
 │   └── timer/            # Timer hook and component tests
 └── App.tsx               # HashRouter + all routes
+
+docs/
+├── adr/                  # Architecture Decision Records
+└── user-guide/           # Host and player guides
 
 public/
 ├── favicon.svg           # SVG favicon (source of truth)
@@ -153,12 +178,13 @@ restore or share your question bank.
 
 ### Workflows
 
-| Workflow        | Trigger                   | Purpose                                                                |
-| --------------- | ------------------------- | ---------------------------------------------------------------------- |
-| `ci.yml`        | PRs to `master`           | PR title lint + type-check, lint, test, build — both required to merge |
-| `deploy.yml`    | push to `master` + manual | Type-check → lint → test → build → deploy to GitHub Pages              |
-| `release.yml`   | push of `v*` tags         | Build tarball → generate release notes → publish GitHub Release        |
-| `automerge.yml` | `CI` workflow completes   | Auto-merge Dependabot patch/minor PRs when CI passes                   |
+| Workflow        | Trigger                        | Purpose                                                                |
+| --------------- | ------------------------------ | ---------------------------------------------------------------------- |
+| `ci.yml`        | PRs to `master`                | PR title lint + type-check, lint, test, build — both required to merge |
+| `deploy.yml`    | push to `master` + manual      | Type-check → lint → test → build → deploy to GitHub Pages              |
+| `docs.yml`      | push to `master` (src/ changes) | Generate TypeDoc → publish to `gh-pages` under `/api/`                |
+| `release.yml`   | push of `v*` tags              | Build tarball → generate release notes → publish GitHub Release        |
+| `automerge.yml` | `CI` workflow completes        | Auto-merge Dependabot patch/minor PRs when CI passes                   |
 
 All workflows set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to opt into the Node 24 runner ahead of the June 2026 forced migration.
 
@@ -179,7 +205,7 @@ Force pushes and branch deletion are blocked. To apply or re-apply protection:
 bash scripts/protect-master.sh
 ```
 
-> **Note:** `scripts/` is gitignored. Add scripts explicitly with `git add --force scripts/`.
+> **Note:** `scripts/` is gitignored. Add scripts explicitly with `git add --force scripts/`
 
 ### Dependabot
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,8 +2,8 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [2, 'always', [
-      'feat', 'fix', 'chore', 'docs', 'refactor',
-      'perf', 'test', 'ci', 'build', 'revert',
+      'feat', 'fix', 'chore', 'refactor',
+      'perf', 'test', 'build', 'revert',
       'epic',
     ]],
     'scope-enum': [1, 'always', [

--- a/docs/adr/0008-transport-dual-peerjs-gun.md
+++ b/docs/adr/0008-transport-dual-peerjs-gun.md
@@ -1,0 +1,71 @@
+# ADR-0008 — Transport layer: dual PeerJS + Gun.js with auto-fallback
+
+**Date:** 2026-04-10
+**Status:** Accepted
+
+## Context
+
+Viktorani is a fully static PWA with no backend (ADR-0001). Real-time communication
+between the GameMaster and players is required for the buzzer, score updates, timer
+broadcasts, and question-navigation events. The transport layer must work in bar
+environments where network conditions are unpredictable.
+
+Two broad options exist for browser-to-browser real-time communication without a
+custom server: WebRTC (with a signalling layer) and relay-based pub/sub.
+
+**Constraints:**
+- Zero server maintenance — no custom signalling or relay server to run.
+- Must work behind restrictive NATs (common in pubs and venues).
+- Latency must be low enough for fair buzzer ordering (< 100 ms typical round-trip).
+- The passphrase displayed on the QR code must provide confidentiality.
+
+## Decision
+
+We implement two transport classes behind a common `ITransport` interface:
+
+1. **`PeerJSTransport`** — WebRTC data channels via the PeerJS cloud signalling service.
+   The host registers a deterministic PeerJS ID (`vkt-<roomId>`); players connect to it.
+   All data flows peer-to-peer with DTLS encryption from the browser.
+
+2. **`GunTransport`** — Decentralised graph database relay via public Gun.js peers.
+   Events are symmetrically encrypted with SEA (`SEA.work(passphrase, roomId)`) before
+   being written to the Gun graph. All peers subscribe to the same namespace and decrypt
+   on receive.
+
+`TransportManager` exposes three modes:
+- `'peer'` — PeerJS only.
+- `'gun'` — Gun.js only.
+- `'auto'` — Try PeerJS; if it times out after 8 seconds, fall back to Gun.js.
+
+The default mode is `'auto'`.
+
+## Alternatives considered
+
+**PeerJS only:** Simpler implementation and lower latency. Rejected as the sole option
+because the PeerJS cloud service has had availability incidents, and WebRTC peer
+connections are blocked by some corporate/venue NATs.
+
+**Gun.js only:** More reliable connectivity (relay-based, firewall-friendly). Rejected
+as the sole option because Gun.js relay peers are public infrastructure with variable
+latency, and the relay-hop model adds ~50–150 ms round-trip compared to PeerJS's
+direct data channel.
+
+**Socket.IO / Pusher / Ably:** Managed WebSocket services. Rejected because they
+require an account, API keys, and introduce per-message costs or strict rate limits.
+They also contradict the zero-server-maintenance constraint.
+
+**WebSockets with a self-hosted relay:** Maximum control and performance. Rejected
+because it requires running a server, which contradicts ADR-0001.
+
+## Consequences
+
+- Hosts can manually override the transport mode per-game if one option is known to
+  work better at their venue.
+- The 8-second PeerJS timeout is a trade-off: short enough not to delay game start
+  noticeably, long enough to distinguish a slow connection from a broken one.
+- Gun.js relay peers are third-party infrastructure. If both public relay servers are
+  unavailable, Gun.js transport will fail. The passphrase-based SEA encryption means
+  relay operators cannot read game events.
+- The `ITransport` interface makes it straightforward to add future transports
+  (e.g. self-hosted WebSocket, BroadcastChannel for same-device testing) without
+  changing consumers.

--- a/docs/adr/0009-dexie-versioned-migrations.md
+++ b/docs/adr/0009-dexie-versioned-migrations.md
@@ -1,0 +1,65 @@
+# ADR-0009 — Database: Dexie.js with versioned migrations
+
+**Date:** 2026-04-10
+**Status:** Accepted
+
+## Context
+
+All application data — questions, games, rounds, players, scores, buzz events — must
+be stored locally in the browser. The project has no backend (ADR-0001), so
+server-side databases are out of scope. The storage layer must support:
+
+- Structured, queryable data (not just key-value blobs).
+- Versioned schema migrations that run automatically on upgrade.
+- React integration without excessive boilerplate.
+- A test-friendly API (mockable in Vitest without a real browser).
+
+IndexedDB is the only browser API that provides a full transactional database.
+The question is which abstraction to use on top of it.
+
+## Decision
+
+We use **Dexie.js** as the IndexedDB abstraction, with all schema definitions
+and migrations in a single `ViktoraniDB` class in `src/db/index.ts`.
+
+Schema evolution uses Dexie's versioned `.version(n).stores({...}).upgrade(tx => ...)`
+pattern. Each version declares the full index set for every table (Dexie requires this)
+and an optional upgrade callback for data migrations. Versions are append-only —
+past versions are never modified.
+
+All React components access the database via `dexie-react-hooks` (`useLiveQuery`)
+or via async helpers imported from `src/db/`. The database is exposed as a
+module-level singleton (`export const db = new ViktoraniDB()`).
+
+For testing, `fake-indexeddb` polyfills the IndexedDB API in the Vitest environment
+(see ADR-0010).
+
+## Alternatives considered
+
+**Raw IndexedDB API:** Maximum control; no dependency. Rejected because the raw API
+is callback-based, verbose, and difficult to use with React's asynchronous rendering
+model. Schema migration code would be substantial to write and maintain.
+
+**localForage:** A simple key-value store on top of IndexedDB. Rejected because it
+does not support indexes or queries — storing structured data like questions with tag
+filtering and sort-by-difficulty would require loading all records into memory.
+
+**PouchDB:** A CouchDB-compatible database with sync capabilities. Rejected because
+sync is not needed (the transport layer handles real-time state), and PouchDB's
+document model and revision history add unnecessary overhead for this use case.
+
+**SQLite via WASM (e.g. wa-sqlite, sql.js):** Full SQL in the browser. Rejected
+because the WASM bundle size (~1 MB) is disproportionate for a trivia app; browser
+support is still maturing; and Dexie covers all required query patterns.
+
+## Consequences
+
+- Schema changes require a new version number. Forgetting to increment the version
+  causes Dexie to throw on open, which surfaces the mistake immediately in development.
+- All tables must be declared in every version's `.stores()` call, even if unchanged.
+  This is verbose but ensures the index set is always explicit.
+- The `upgrade()` callback receives a Dexie transaction; long-running migrations
+  (e.g. backfilling many rows) block the database open. This is acceptable for the
+  current data volumes (hundreds of questions, not millions).
+- `fake-indexeddb` supports Dexie out of the box, making unit tests fast and
+  deterministic without a browser.

--- a/docs/adr/0010-pwa-offline-first.md
+++ b/docs/adr/0010-pwa-offline-first.md
@@ -1,0 +1,69 @@
+# ADR-0010 — PWA / offline-first strategy
+
+**Date:** 2026-04-10
+**Status:** Accepted
+
+## Context
+
+Viktorani is designed for bar and pub environments where Wi-Fi is unreliable and
+mobile data is often congested. The host device must be able to run the GM view
+without any internet connection once the app is loaded. Players who have visited
+the site before should also be able to load the join page without connectivity.
+
+Additionally, the app should be installable as a home-screen icon on the host's
+tablet or laptop, behaving like a native app (no browser chrome, standalone window).
+
+## Decision
+
+We build Viktorani as a **Progressive Web App (PWA)** using `vite-plugin-pwa`,
+which generates a service worker and a Web App Manifest automatically from Vite's
+build output.
+
+**Service worker strategy:** `GenerateSW` with a `workbox` `StaleWhileRevalidate`
+strategy for all assets. On first visit, all build artifacts are cached. On subsequent
+visits, the cached version is served immediately while the new version is fetched in
+the background. On next reload, the updated version is active.
+
+**Manifest:** Declares `display: standalone`, a 192×192 and 512×512 PNG icon set,
+and a `start_url` of `/viktorani/` (matching the GitHub Pages subpath).
+
+**Offline capability scope:**
+- The GM can run a full game offline: questions, navigation, buzzer logic, and scoring
+  all work without any network request.
+- The real-time transport (PeerJS / Gun.js) requires internet for initial connection.
+  Once the game is in progress, PeerJS direct data channels survive brief connectivity
+  drops; Gun.js buffers events and replays on reconnect.
+- Player devices need internet for the initial page load; after caching they can
+  reload offline but will not receive transport events without connectivity.
+
+**Peer conflict:** `vite-plugin-pwa` declares a peer dependency on a specific Vite
+major version. With Vite 8, this peer constraint is satisfied via an npm `overrides`
+block in `package.json` rather than downgrading Vite.
+
+## Alternatives considered
+
+**No service worker (plain static site):** Simpler build. Rejected because offline
+operation is a primary design requirement — bar Wi-Fi is notoriously unreliable.
+
+**Manual service worker:** Full control over caching strategy. Rejected because
+Workbox (used by `vite-plugin-pwa`) handles cache versioning, update detection, and
+the `skipWaiting` / `clientsClaim` lifecycle correctly out of the box. Writing this
+manually would be substantial and error-prone.
+
+**Capacitor / Electron (native wrapper):** True offline native app. Rejected because
+it would require a build and distribution pipeline (App Store, DMG/EXE) that
+contradicts the zero-cost, zero-maintenance deployment goal. A PWA achieves
+install-to-home-screen on iOS/Android/desktop without any store submission.
+
+## Consequences
+
+- The host must load the app at least once on a network-connected device before
+  going offline. This is a reasonable requirement for a planned event.
+- Service worker updates are silent (StaleWhileRevalidate). If the host wants to
+  pick up a new version immediately, they need to close all tabs and reopen, or
+  use the browser's "Update" prompt if one appears.
+- The `display: standalone` manifest requires `HashRouter` instead of `BrowserRouter`
+  because GitHub Pages cannot serve arbitrary deep paths (see ADR-0004).
+- PWA install prompts behave differently across browsers and OS versions. Chrome on
+  Android and Edge on desktop show an install prompt; Safari on iOS requires the user
+  to manually "Add to Home Screen" from the share sheet.

--- a/docs/adr/0011-tag-only-classification.md
+++ b/docs/adr/0011-tag-only-classification.md
@@ -1,0 +1,53 @@
+# ADR-0011 — Tag-only question classification
+
+**Date:** 2026-04-10
+**Status:** Accepted
+
+## Context
+
+See ADR-0007, which documents the decision to remove the `Category` type and make
+tags the sole question classifier. This ADR records the consequences and implementation
+details that were deferred from ADR-0007.
+
+The original system had:
+- **Categories** — a single required classifier per question (e.g. "Geography").
+- **Tags** — an optional multi-value set for additional labels.
+
+Both were colour-coded and managed in separate Settings panels. The duplication
+created authoring friction (which label goes where?) and made filtering inconsistent.
+
+## Decision
+
+Remove the `Category` type entirely. Tags are the sole classifier. The filtering UI
+upgrades from a single-select category dropdown to a **tri-state per-tag** model:
+
+- **None** (default) — tag is not used as a filter criterion.
+- **Include** — question must have this tag (conjunctive AND across multiple includes).
+- **Exclude** — question must not have this tag (conjunctive AND across multiple excludes).
+
+Includes and excludes compose: "must have `History` AND must not have `Hard`" is a
+valid filter state.
+
+The DB is migrated from v2 to v3 (see `src/db/index.ts`) with a Dexie upgrade step
+that strips `categoryId` from all existing `questions` records and drops the
+`categories` table. The snapshot format is bumped to v2 (categories field dropped);
+v1 imports remain supported with categories silently ignored.
+
+## Alternatives considered
+
+See ADR-0007 for the full alternatives analysis.
+
+## Consequences
+
+- `Question.categoryId` is removed from the TypeScript schema and all DB indexes.
+  Existing data is migrated automatically on first open after the upgrade.
+- The `ManageCategories` settings panel is deleted. Tag management is consolidated
+  into the expanded `ManageTags` panel.
+- Snapshot v2 does not include a `categories` field. Importing a v1 backup on a
+  v3+ database silently discards the categories array and strips `categoryId` from
+  imported questions.
+- Tri-state tag filtering is more expressive than the old single-select dropdown
+  but requires users to understand include vs. exclude semantics. The UI communicates
+  this via colour coding (green = include, red = exclude, grey = none).
+- Search index no longer includes `_categoryName`. Tag names are already indexed by
+  Fuse.js, so coverage is equivalent.

--- a/docs/adr/0012-vitest-vmforks-pool.md
+++ b/docs/adr/0012-vitest-vmforks-pool.md
@@ -1,0 +1,66 @@
+# ADR-0012 — Vitest vmForks pool for ESM compatibility
+
+**Date:** 2026-04-10
+**Status:** Accepted
+
+## Context
+
+The project uses `fake-indexeddb` to polyfill IndexedDB in tests. Starting with
+`fake-indexeddb` v5+, the package is published as pure ESM with top-level `await`
+in its module initialisation. Node.js cannot `require()` a module that contains
+top-level `await` — doing so throws:
+
+```
+ERR_REQUIRE_ASYNC_MODULE
+```
+
+Vitest's default worker pool (`forks`) loads test modules via a CommonJS-compatible
+require shim, which triggers this error when any test file imports `fake-indexeddb`
+(directly or transitively via `src/db/`).
+
+## Decision
+
+DB-touching test files annotate their pool requirement at the top of the file:
+
+```ts
+// @vitest-pool vmForks
+```
+
+The `vmForks` pool runs each test file in a separate Node.js VM context using the
+native ES Module loader. Top-level `await` is handled correctly in this mode.
+
+The annotation is placed **per-file** on tests that import from `src/db/`, rather
+than globally in `vite.config.ts`. This keeps non-DB tests running in the faster
+default pool.
+
+## Alternatives considered
+
+**Set `pool: 'vmForks'` globally in `vite.config.ts`:** Simpler configuration —
+no per-file annotation needed. Rejected because `vmForks` has higher startup
+overhead than `forks`. Applying it globally would slow down the non-DB test suite
+(transport utilities, hook unit tests) unnecessarily.
+
+**Downgrade `fake-indexeddb` to v4:** v4 is CommonJS-compatible and works with the
+default pool. Rejected because v4 is significantly behind v6 (current), lacks bug
+fixes, and pinning old major versions creates upgrade friction.
+
+**Mock `src/db/` at the module level:** Replace the real Dexie database with a
+hand-written mock in all tests. Rejected because it would create a second
+implementation of query logic that can drift from the real one, defeating the purpose
+of integration tests.
+
+**Use `@vitest/browser`:** Run tests in a real browser where IndexedDB is natively
+available. Rejected because browser tests have much higher CI overhead (requires
+Playwright) and are better suited to E2E testing than the unit/integration tests
+that currently cover DB behaviour.
+
+## Consequences
+
+- Any new test file that imports from `src/db/` or from any hook that accesses the DB
+  must include the `// @vitest-pool vmForks` annotation. Forgetting it produces the
+  `ERR_REQUIRE_ASYNC_MODULE` error, which is a clear signal that the annotation is needed.
+- The annotation is file-level, so a single test file cannot mix DB and non-DB
+  concerns without paying the `vmForks` startup cost for all tests in the file.
+  In practice this is not a constraint because DB and non-DB logic are in separate files.
+- CI run times are acceptable: the vmForks overhead is ~100–200 ms per file, and
+  there are currently only a handful of DB-touching test files.

--- a/docs/user-guide/host.md
+++ b/docs/user-guide/host.md
@@ -1,0 +1,205 @@
+# Host Guide
+
+Everything you need to run a trivia night with Viktorani.
+
+---
+
+## Contents
+
+1. [Creating a question bank](#1-creating-a-question-bank)
+2. [Building a game](#2-building-a-game)
+3. [Running a game](#3-running-a-game)
+4. [During a round](#4-during-a-round)
+5. [Timer usage](#5-timer-usage)
+6. [Ending the game](#6-ending-the-game)
+
+---
+
+## 1. Creating a question bank
+
+### Difficulties
+
+Go to **Settings → Difficulties** to define point values for your game.
+The defaults are Easy (5 pts), Medium (10 pts), and Hard (15 pts).
+You can rename them, change their colours, and adjust their scores.
+
+### Tags
+
+Go to **Settings → Tags** to create classifiers for your questions.
+Tags are used for filtering — you can include or exclude by tag when browsing questions.
+Example tags: `History`, `Pop Culture`, `Music`, `Local`.
+
+### Adding questions
+
+Go to **Questions → Add Question**. Fill in:
+
+| Field | Required | Notes |
+|---|---|---|
+| Title | ✓ | The question text shown to players |
+| Type | ✓ | See question types below |
+| Answer | ✓ | Correct answer (not shown to players automatically) |
+| Difficulty | — | Determines point value on correct buzz |
+| Tags | — | Multi-select; used for filtering |
+| Description | — | Markdown body (flavour text, citations) |
+| Media | — | Upload an image, audio, or video file |
+
+#### Question types
+
+**Multiple choice** — Provide exactly 4 options; mark one as the correct answer.
+
+```
+Title:   Which planet has the most moons?
+Options: Jupiter / Saturn / Uranus / Neptune
+Answer:  Saturn
+```
+
+**True / False** — Options are fixed as `True` and `False`; mark the correct one.
+
+```
+Title:  The Great Wall of China is visible from space.
+Answer: False
+```
+
+**Open-ended** — No options shown; the GM reads the answer and rules manually.
+
+```
+Title:  Who wrote Hamlet?
+Answer: Shakespeare
+```
+
+### Bulk import
+
+You can import many questions at once via **Questions → Import**.
+Download the example file first to see the expected JSON structure.
+Required fields per row: `title`, `type`, `answer`.
+
+---
+
+## 2. Building a game
+
+Go to **Games → Create Game**.
+
+### Add rounds
+
+A game contains one or more rounds. Each round is an ordered list of questions.
+
+1. Click **Add Round** to create a round.
+2. Click the round to open it.
+3. Click **Add Questions** to search and select questions from your bank.
+4. Drag rows to reorder questions within a round.
+
+### Configure the game
+
+On the game settings panel you can configure:
+
+| Option | What it does |
+|---|---|
+| Transport mode | `Auto` (PeerJS → Gun fallback), `PeerJS only`, or `Gun only` |
+| Scoring enabled | Award points automatically on correct buzz adjudication |
+| Auto-lock on first correct | Lock the buzzer after the first correct ruling |
+| Allow false starts | Record buzzes that arrive while the buzzer is locked |
+| Buzz deduplication | `First only` (one buzz per player per question) or `All` |
+
+---
+
+## 3. Running a game
+
+Open a game and click **Start Game** to enter the GameMaster (GM) view.
+
+### Sharing the room
+
+When the game starts, a room code and QR code are generated.
+
+```
+Room:       XK7RQZ
+Passphrase: tiger-lamp-cloud-seven
+```
+
+Players can join by:
+- Scanning the QR code with their phone camera.
+- Visiting the Viktorani URL and entering the room code manually.
+
+The QR code links directly to the join page with the room and passphrase pre-filled.
+
+### Lobby
+
+The GM sees a list of connected players in real time. Each player appears as they join.
+Once everyone is in, click **Start** to begin the first round.
+
+> **Solo / offline play:** You can skip the lobby and start immediately by clicking
+> **Start Solo**. No players need to be connected.
+
+---
+
+## 4. During a round
+
+### Displaying a question
+
+The GM view shows the current question title, answer options, and media.
+Players see only what the GM explicitly reveals using the visibility toggles:
+
+| Toggle | What players see |
+|---|---|
+| Show Question | Question title |
+| Show Answers | Answer options (MC/TF only) |
+| Show Media | Attached image, audio, or video |
+
+### Navigating questions
+
+Use the **Previous** / **Next** buttons or keyboard arrows to move between questions.
+The current position (round · question) is shown in the navigation bar.
+Reaching the end of a round shows a round-boundary overlay before advancing.
+
+### Managing the buzzer
+
+1. Click **Unlock** to open the buzzer — players can now buzz in.
+2. The buzz list shows players in arrival order (timestamp-sorted).
+3. Click **Correct**, **Incorrect**, or **Skip** next to a player's name.
+   - **Correct** awards points (if scoring is enabled) and optionally auto-locks.
+   - **Incorrect** marks the buzz but leaves the buzzer open for others.
+   - **Skip** dismisses the buzz without recording a ruling.
+4. Click **Lock** to close the buzzer manually at any time.
+5. Click **Clear buzzes** to reset the list for the current question.
+
+### Manual score adjustments
+
+The scoreboard panel shows all players/teams with `+` and `−` buttons.
+Click them to apply a one-step delta (defaulting to the lowest difficulty score).
+Score changes are broadcast to players immediately.
+
+---
+
+## 5. Timer usage
+
+Timers can be used for timed rounds, thinking time, or dramatic effect.
+
+### Creating a timer
+
+1. In the GM view, open the **Timers** widget.
+2. Click **Add Timer**.
+3. Set the label (e.g. `"Thinking time"`), duration in seconds, and target audience.
+4. Click **Start**.
+
+The timer is broadcast to all players (or a specific team) and counts down live.
+
+### Controls
+
+| Action | Effect |
+|---|---|
+| Pause | Freeze the countdown at its current value |
+| Resume | Continue from where it paused |
+| Reset | Return to the full duration |
+| Stop / Remove | End the timer and hide it from players |
+
+---
+
+## 6. Ending the game
+
+When all rounds are complete (or you choose to end early):
+
+1. Click **End Game** in the GM view.
+2. The scoreboard widget shows the final rankings.
+3. Click **Export Results** to download a JSON file with all scores and buzz history.
+
+The game record remains in your local database until you delete it or purge all data
+via **Settings → Database → Purge**.

--- a/docs/user-guide/player.md
+++ b/docs/user-guide/player.md
@@ -1,0 +1,138 @@
+# Player Guide
+
+How to join and play a Viktorani trivia game.
+
+---
+
+## Contents
+
+1. [Joining a game](#1-joining-a-game)
+2. [Online play](#2-online-play)
+3. [Offline / no-device play](#3-offline--no-device-play)
+4. [Troubleshooting](#4-troubleshooting)
+
+---
+
+## 1. Joining a game
+
+Your host will display a QR code or read out a room code at the start of the game.
+
+### Option A — Scan the QR code
+
+1. Open your phone's camera app and point it at the QR code.
+2. Tap the link that appears — it opens Viktorani in your browser.
+3. Your name field is pre-filled from a previous session (if any); edit it if needed.
+4. Tap **Join**.
+
+### Option B — Enter the room code manually
+
+1. Open **https://morbeo.github.io/viktorani/** in your browser.
+2. Tap **Join Game**.
+3. Enter the six-character room code (e.g. `XK7RQZ`) — it's not case-sensitive.
+4. Enter the passphrase shown by your host (e.g. `tiger-lamp-cloud-seven`).
+5. Enter your name and tap **Join**.
+
+> **Teams:** If your host has configured team play, you'll be assigned to a team
+> during the lobby phase. Your host will tell you which team you're on.
+
+---
+
+## 2. Online play
+
+Once you've joined, you'll see the **Player view**. The game progresses as the GM
+navigates through questions.
+
+### What you see
+
+The GM controls what's visible to you:
+
+| GM toggles on | You see |
+|---|---|
+| Show Question | The question text |
+| Show Answers | Answer options (multiple choice / true-false) |
+| Show Media | An image, audio clip, or video |
+
+### Buzzing in
+
+When the GM unlocks the buzzer, a **Buzz** button appears.
+
+1. Tap **Buzz** as fast as you can.
+2. Your buzz is recorded with a high-precision timestamp.
+3. The GM sees buzzes in arrival order and rules each one: Correct / Incorrect / Skip.
+4. If your buzz is ruled Incorrect, the buzzer may reopen for others depending on the game settings.
+
+### Scoreboard
+
+The scoreboard updates live after each adjudication.
+Scores are sorted in descending order so you can see the rankings at a glance.
+
+### Timers
+
+If the GM starts a countdown timer, it appears on your screen automatically and counts down.
+You cannot pause or reset timers — only the GM can control them.
+
+---
+
+## 3. Offline / no-device play
+
+Viktorani supports games where some teams share one device, or where players have no device at all.
+
+### Shared-device teams
+
+If your team shares a single phone:
+
+1. One person joins Viktorani as the team representative.
+2. The rest of the team huddles around and discusses answers together.
+3. The representative buzzes in and the GM hears the team's answer.
+
+### Paper / no-device teams
+
+For venues with poor connectivity or players without smartphones:
+
+1. Each no-device team designates a scorekeeper.
+2. The host (GM) manages that team's score manually using the scoreboard `+` / `−` buttons.
+3. Buzzes for no-device teams are entered by the GM directly using manual score adjustment.
+
+### Planned: QR answer submission
+
+A future version of Viktorani will let the GM display a per-question QR code.
+Players with no app installed will be able to scan it and submit an answer via a
+lightweight one-page form — no join flow required. This is designed for pub settings
+where some guests prefer not to install anything.
+
+---
+
+## 4. Troubleshooting
+
+### The QR code won't scan
+
+- Make sure your camera app supports QR scanning (most modern phones do natively).
+- Increase the screen brightness on the host's display.
+- Try **Option B** (manual room code) instead.
+
+### I entered the room code but can't connect
+
+- Double-check the room code — the character set avoids `0`, `1`, `I`, and `O`
+  to prevent confusion, so `0` and `O` are never valid characters.
+- Make sure the passphrase matches exactly, including hyphens (e.g. `tiger-lamp-cloud-seven`).
+- Ask your host to confirm the game has started (not still in lobby setup).
+
+### My connection dropped mid-game
+
+- Refresh the page and re-join using the same room code and passphrase.
+- Your name and score are preserved in the host's session.
+- If the host's transport mode is `Gun.js`, the connection will re-establish automatically
+  within a few seconds without needing to re-join.
+
+### I can't hear the timer / media
+
+- Check that your device volume is not muted.
+- Some browsers block autoplay of audio until the user has interacted with the page.
+  Tap anywhere on the screen once and the audio should start.
+
+### The wrong passphrase error
+
+- Passphrases are case-insensitive but must include the hyphens between words.
+- If you're on the Gun.js transport, the passphrase is used for encryption —
+  a mismatch means you won't receive any events, not that connection fails outright.
+  Ask your host to confirm the passphrase and re-join.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "prettier": "^3.8.1",
         "release-it": "^19.2.4",
         "tailwindcss": "^4.2.2",
+        "typedoc": "^0.28.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1",
@@ -1896,6 +1897,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "dev": true,
@@ -2065,6 +2077,20 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3208,6 +3234,55 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
@@ -8033,6 +8108,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "dev": true,
@@ -8248,6 +8333,13 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "dev": true,
@@ -8308,6 +8400,37 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -8580,6 +8703,13 @@
       "version": "2.27.1",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -9896,6 +10026,16 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11339,6 +11479,69 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/typedoc": {
+      "version": "0.28.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.18.tgz",
+      "integrity": "sha512-NTWTUOFRQ9+SGKKTuWKUioUkjxNwtS3JDRPVKZAXGHZy2wCA8bdv2iJiyeePn0xkmK+TCCqZFT0X7+2+FLjngA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -11373,6 +11576,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "release-it": "^19.2.4",
     "tailwindcss": "^4.2.2",
     "typedoc": "^0.28.0",
-    "typedoc-plugin-markdown": "^4.6.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "docs": "typedoc",
     "pack": "bash scripts/pack.sh",
     "release": "release-it",
     "release:dry": "release-it --dry-run",
@@ -59,6 +60,8 @@
     "prettier": "^3.8.1",
     "release-it": "^19.2.4",
     "tailwindcss": "^4.2.2",
+    "typedoc": "^0.28.0",
+    "typedoc-plugin-markdown": "^4.6.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,13 +2,52 @@ import Dexie, { type EntityTable } from 'dexie'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
+/** The three structural question formats supported by the question bank. */
 export type QuestionType = 'multiple_choice' | 'true_false' | 'open_ended'
+
+/**
+ * Difficulty level identifier — either one of the built-in slugs or
+ * a custom string defined in the Difficulties settings panel.
+ */
 export type Difficulty = 'easy' | 'medium' | 'hard' | string
+
+/** Lifecycle state of a {@link Game} session. */
 export type GameStatus = 'waiting' | 'active' | 'paused' | 'ended'
+
+/** Which underlying transport a game uses for real-time communication. */
 export type TransportMode = 'auto' | 'peer' | 'gun'
+
+/** The GameMaster's ruling on a single buzz. */
 export type GmDecision = 'Correct' | 'Incorrect' | 'Skip'
+
+/**
+ * Controls whether only the first buzz per player per question is shown,
+ * or all buzzes (including subsequent ones) are recorded.
+ */
 export type BuzzDeduplication = 'firstOnly' | 'all'
+
+/**
+ * Who receives an audio beep when a timer expires.
+ * `'none'` — no audio; `'host'` — GM only; `'players'` — players only; `'both'` — everyone.
+ */
+export type TimerNotify = 'none' | 'host' | 'players' | 'both'
+
+/**
+ * When (if ever) a timer resets automatically to its full duration.
+ * `'none'` — never; `'question'` — on question change; `'round'` — on round change; `'any'` — on either.
+ */
+export type TimerAutoReset = 'none' | 'question' | 'round' | 'any'
+
+/**
+ * Strategy for breaking ties when two buzzes arrive with identical timestamps.
+ * Currently only server-arrival order is supported.
+ */
 export type TiebreakerMode = 'serverOrder'
+
+/**
+ * The set of widget types that can be placed in a GM layout.
+ * Each type maps to a distinct React component in the GameMaster screen.
+ */
 export type WidgetType =
   | 'buzzer'
   | 'question'
@@ -27,59 +66,103 @@ export type WidgetType =
   | 'game_controls'
   | 'progress'
 
+/**
+ * A configurable difficulty tier with a point value and display colour.
+ * Stored in the `difficulties` collection; seeded with Easy / Medium / Hard on first run.
+ */
 export interface DifficultyLevel {
   id: string
   name: string
+  /** Points awarded when a player answers a question at this difficulty correctly. */
   score: number
+  /** CSS hex colour used in the UI (e.g. `'#27ae60'`). */
   color: string
+  /** Zero-based display order in lists and dropdowns. */
   order: number
 }
 
+/**
+ * A question classifier. Tags replace the legacy category system (see ADR-0007).
+ * A question can have zero or more tags; filtering is tri-state per tag.
+ */
 export interface Tag {
   id: string
   name: string
+  /** CSS hex colour for the tag pill (e.g. `'#9b59b6'`). */
   color: string
 }
 
+/**
+ * A single trivia question in the question bank.
+ *
+ * @remarks
+ * - `type === 'multiple_choice'`: `options` holds exactly 4 strings; `answer` is one of them.
+ * - `type === 'true_false'`: `options` is `['True', 'False']`; `answer` is one of them.
+ * - `type === 'open_ended'`: `options` is empty; `answer` is the canonical correct answer.
+ */
 export interface Question {
   id: string
   title: string
   type: QuestionType
-  options: string[] // multiple_choice: 4 items; true_false: ['True','False']
-  answer: string // correct answer
-  description: string // markdown
+  /** Possible answers shown to players (MC and T/F only). */
+  options: string[]
+  /** The canonical correct answer string. */
+  answer: string
+  /** Optional markdown body shown below the question title. */
+  description: string
+  /** ID of the associated {@link DifficultyLevel}, or `null` if unset. */
   difficulty: string | null
+  /** Array of {@link Tag} IDs. */
   tags: string[]
-  media: string | null // base64 or URL
+  /** Base64-encoded media data or a remote URL, or `null` if none. */
+  media: string | null
   mediaType: 'image' | 'audio' | 'video' | null
   createdAt: number
   updatedAt: number
 }
 
+/**
+ * An ordered collection of questions that forms one section of a {@link Game}.
+ */
 export interface Round {
   id: string
   name: string
   description: string
-  questionIds: string[] // ordered
+  /** Ordered array of {@link Question} IDs. */
+  questionIds: string[]
   createdAt: number
 }
 
+/**
+ * A complete game session including configuration, real-time state, and navigation position.
+ *
+ * @remarks
+ * The `buzzerLocked` flag and `showQuestion / showAnswers / showMedia` fields are
+ * the authoritative source of truth for the current question's display state.
+ * They are synced to players via transport events (`BUZZER_LOCK`, `VISIBILITY`, etc.)
+ * whenever the GM changes them.
+ */
 export interface Game {
   id: string
   name: string
   status: GameStatus
   transportMode: TransportMode
+  /** Six-character room code shared with players (e.g. `'XK7RQZ'`). `null` before the game starts. */
   roomId: string | null
-  passphrase: string | null // Gun.js SEA encryption
+  /** Four-word Gun.js SEA passphrase. `null` before the game starts. */
+  passphrase: string | null
   // Visibility
   showQuestion: boolean
   showAnswers: boolean
   showMedia: boolean
   // Players / teams
-  maxTeams: number // 0 = unlimited
-  maxPerTeam: number // 0 = unlimited
+  /** Maximum number of teams allowed; `0` means unlimited. */
+  maxTeams: number
+  /** Maximum players per team; `0` means unlimited. */
+  maxPerTeam: number
   allowIndividual: boolean
   // Rounds / navigation
+  /** Ordered array of {@link Round} IDs. */
   roundIds: string[]
   currentRoundIdx: number
   currentQuestionIdx: number
@@ -87,7 +170,9 @@ export interface Game {
   buzzerLocked: boolean
   // Buzzer configuration
   scoringEnabled: boolean
+  /** Lock the buzzer automatically after the first correct adjudication. */
   autoLockOnFirstCorrect: boolean
+  /** Whether false-start buzzes (arriving while locked) are recorded. */
   allowFalseStarts: boolean
   buzzDeduplication: BuzzDeduplication
   tiebreakerMode: TiebreakerMode
@@ -96,6 +181,7 @@ export interface Game {
   updatedAt: number
 }
 
+/** A team of players within a {@link Game}. Scores are aggregated from member players. */
 export interface Team {
   id: string
   gameId: string
@@ -104,17 +190,29 @@ export interface Team {
   score: number
 }
 
+/** A player connected to a {@link Game} session. */
 export interface Player {
   id: string
   gameId: string
   name: string
+  /** `null` if the player is not on a team (individual mode). */
   teamId: string | null
   score: number
+  /** `true` when the player's tab is backgrounded (detected via Page Visibility API). */
   isAway: boolean
+  /** Stable browser-local UUID stored in `localStorage` to deduplicate rejoins. */
   deviceId: string
   joinedAt: number
 }
 
+/**
+ * A single buzz event recorded during a question.
+ *
+ * @remarks
+ * `timestamp` uses `performance.now()` offset from `Date.now()` at session start
+ * to provide sub-millisecond precision for ordering simultaneous buzzes.
+ * `isFalseStart` is set when the buzz arrived while `buzzerLocked` was `true`.
+ */
 export interface BuzzEvent {
   id: string
   gameId: string
@@ -122,73 +220,110 @@ export interface BuzzEvent {
   playerId: string
   playerName: string
   teamId: string | null
-  /** microsecond precision via performance.now() offset from Date.now() */
+  /** High-precision client-side timestamp for ordering (microseconds). */
   timestamp: number
-  /** true when buzz arrived before buzzerLocked was cleared */
+  /** `true` when the buzz arrived before the GM unlocked the buzzer. */
   isFalseStart: boolean
   gmDecision: GmDecision | null
   decidedAt: number | null
 }
 
+/**
+ * A named arrangement of {@link Widget}s displayed on the GM screen.
+ *
+ * @remarks
+ * `gameId === null` indicates a global reusable template.
+ * `isActive` marks which layout is currently shown in the GM view.
+ * The four default layouts correspond to game phases: lobby, active question,
+ * scoreboard, and results.
+ */
 export interface Layout {
   id: string
-  gameId: string | null // null = global template
+  /** `null` for global templates not tied to a specific game. */
+  gameId: string | null
   name: string
   target: 'admin' | 'player'
   isActive: boolean
+  /** Display order within the layout switcher. */
   order: number
 }
 
+/**
+ * A single panel within a {@link Layout}.
+ * `config` is an opaque object whose shape depends on `type`.
+ */
 export interface Widget {
   id: string
   layoutId: string
   type: WidgetType
   config: Record<string, unknown>
   width: 'full' | 'half'
+  /** Display order within the layout grid. */
   order: number
 }
 
+/** A freeform markdown note for the GameMaster's use (e.g. round intros, hints). */
 export interface Note {
   id: string
   name: string
-  content: string // markdown
+  content: string
   createdAt: number
   updatedAt: number
 }
 
-export type TimerNotify = 'none' | 'host' | 'players' | 'both'
-export type TimerAutoReset = 'none' | 'question' | 'round' | 'any'
-
+/**
+ * A countdown timer that can be broadcast to players.
+ *
+ * @remarks
+ * `target === 'all'` broadcasts to everyone; `'admin'` shows only on the GM screen;
+ * a team or player ID restricts visibility to that entity.
+ */
 export interface Timer {
   id: string
   gameId: string
   label: string
-  duration: number // seconds
+  /** Total duration in seconds. */
+  duration: number
+  /** Remaining seconds at the last pause/update. */
   remaining: number
-  target: 'all' | 'admin' | string // teamId or playerId
+  target: 'all' | 'admin' | string
   message: string
   visible: boolean
   paused: boolean
+  /** `Date.now()` value when the timer last started (or `null` if not yet started). */
   startedAt: number | null
-  /** Who hears the audio beep when the timer hits zero */
+  /** Who hears the audio beep on expiry. */
   audioNotify: TimerNotify
-  /** Who sees the visual popup when the timer hits zero */
+  /** Who sees the visual flash on expiry. */
   visualNotify: TimerNotify
-  /** Which navigation event auto-resets (pauses + restores remaining) this timer */
+  /** Whether and when the timer resets automatically. */
   autoReset: TimerAutoReset
 }
 
+/**
+ * Tracks the GM's adjudication status for each question in a game.
+ * Created when a question is first visited; updated as the GM rules on buzzes.
+ */
 export interface GameQuestion {
   id: string
   gameId: string
   questionId: string
   roundId: string
+  /** Position within the round (zero-based). */
   order: number
   status: 'pending' | 'correct' | 'incorrect' | 'skipped'
 }
 
 // ── Database ─────────────────────────────────────────────────────────────────
 
+/**
+ * Main Dexie database class. Exported as the {@link db} singleton.
+ *
+ * Schema versions:
+ * - **v2**: Initial schema with `categories` table and `categoryId` on questions.
+ * - **v3**: Drop `categories`; remove `categoryId` index (ADR-0007).
+ * - **v4**: Full `BuzzEvent` schema + buzzer-config back-fill on `Game` records.
+ */
 class ViktoraniDB extends Dexie {
   difficulties!: EntityTable<DifficultyLevel, 'id'>
   tags!: EntityTable<Tag, 'id'>
@@ -289,43 +424,24 @@ class ViktoraniDB extends Dexie {
             if (b['decidedAt'] === undefined) b['decidedAt'] = null
           })
       })
-
-    // v5: add audioNotify, visualNotify, autoReset to timers
-    this.version(5)
-      .stores({
-        difficulties: 'id, name, order',
-        tags: 'id, name',
-        questions: 'id, difficulty, type, createdAt',
-        rounds: 'id, createdAt',
-        games: 'id, status, createdAt',
-        teams: 'id, gameId',
-        players: 'id, gameId, teamId, deviceId',
-        buzzEvents: 'id, gameId, playerId, questionId, timestamp',
-        layouts: 'id, gameId, target',
-        widgets: 'id, layoutId, order',
-        notes: 'id, name, createdAt, updatedAt',
-        timers: 'id, gameId',
-        gameQuestions: 'id, gameId, roundId, order',
-      })
-      .upgrade(async tx => {
-        await tx
-          .table('timers')
-          .toCollection()
-          .modify((t: Record<string, unknown>) => {
-            if (t['audioNotify'] === undefined) t['audioNotify'] = 'none'
-            if (t['visualNotify'] === undefined) t['visualNotify'] = 'none'
-            if (t['autoReset'] === undefined) t['autoReset'] = 'none'
-          })
-      })
   }
 }
 
+/** Module-level singleton. Import and use this in all hooks and pages. */
 export const db = new ViktoraniDB()
 
 // ── Seed defaults ─────────────────────────────────────────────────────────────
 
 let _seeding = false
 
+/**
+ * Populate the database with default difficulty levels and tags on first run.
+ *
+ * @remarks
+ * Guarded against concurrent invocations (e.g. React StrictMode double-invoke)
+ * via the `_seeding` flag. Safe to call multiple times — it is a no-op after
+ * the first successful seed.
+ */
 export async function seedDefaults() {
   // Guard against concurrent calls (e.g. StrictMode double-invoke)
   if (_seeding) return
@@ -360,6 +476,13 @@ export async function seedDefaults() {
   }
 }
 
+/**
+ * Permanently delete all data from every collection.
+ *
+ * @remarks
+ * Runs inside a single Dexie transaction so the wipe is atomic.
+ * Called from the Settings page after a two-step confirmation.
+ */
 export async function purgeDatabase(): Promise<void> {
   await db.transaction(
     'rw',

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -324,7 +324,7 @@ export interface GameQuestion {
  * - **v3**: Drop `categories`; remove `categoryId` index (ADR-0007).
  * - **v4**: Full `BuzzEvent` schema + buzzer-config back-fill on `Game` records.
  */
-class ViktoraniDB extends Dexie {
+export class ViktoraniDB extends Dexie {
   difficulties!: EntityTable<DifficultyLevel, 'id'>
   tags!: EntityTable<Tag, 'id'>
   questions!: EntityTable<Question, 'id'>

--- a/src/db/snapshot.ts
+++ b/src/db/snapshot.ts
@@ -1,6 +1,18 @@
 import { db } from '@/db'
 import type { DifficultyLevel, Tag, Question, Round, Game, Note } from '@/db'
 
+/**
+ * Full database snapshot used for backup and restore.
+ *
+ * @remarks
+ * Version history:
+ * - **v1**: Included a `categories` array (now ignored on import).
+ * - **v2**: Categories removed; tags are the sole classifier.
+ *
+ * Runtime-only collections (`players`, `teams`, `buzzEvents`, `timers`,
+ * `gameQuestions`, `layouts`, `widgets`) are intentionally excluded —
+ * they represent transient session state that is not meaningful to restore.
+ */
 export interface DatabaseSnapshot {
   version: number
   exportedAt: number
@@ -12,6 +24,13 @@ export interface DatabaseSnapshot {
   notes: Note[]
 }
 
+/**
+ * Serialise the question bank and game definitions to a JSON file download.
+ *
+ * @remarks
+ * Triggers a browser file-save dialog. The downloaded file can be imported
+ * on another device via {@link importDatabase}.
+ */
 export async function exportDatabase(): Promise<void> {
   const snapshot: DatabaseSnapshot = {
     version: 2,
@@ -33,6 +52,17 @@ export async function exportDatabase(): Promise<void> {
   URL.revokeObjectURL(url)
 }
 
+/**
+ * Restore a previously exported snapshot into the local database.
+ *
+ * @remarks
+ * Uses `bulkPut` so existing records with matching IDs are overwritten.
+ * Accepts both v1 (with categories) and v2 snapshots — `categoryId` fields
+ * are stripped from question records transparently.
+ *
+ * @param file - A `.json` file previously produced by {@link exportDatabase}.
+ * @throws If the file contains an unsupported snapshot version.
+ */
 export async function importDatabase(file: File): Promise<void> {
   const text = await file.text()
   const snapshot = JSON.parse(text) as DatabaseSnapshot & {
@@ -67,6 +97,7 @@ export async function importDatabase(file: File): Promise<void> {
 
 // ── Questions import/export ───────────────────────────────────────────────────
 
+/** Summary returned by {@link importQuestions} after processing a file. */
 export interface ImportResult {
   imported: number
   skipped: number
@@ -75,6 +106,24 @@ export interface ImportResult {
 
 const REQUIRED_FIELDS = ['title', 'type', 'answer'] as const
 
+/**
+ * Import questions from a JSON array file into the question bank.
+ *
+ * @remarks
+ * Each element must have at least `title`, `type`, and `answer`.
+ * Rows missing required fields are skipped and reported in `errors`.
+ * Uses `db.questions.put` so existing records with matching `id` are updated.
+ *
+ * @param file - A `.json` file containing an array of partial {@link Question} objects.
+ * @returns A summary with counts of imported, skipped, and error rows.
+ * @throws If the file is not valid JSON or is not a JSON array.
+ *
+ * @example
+ * ```ts
+ * const result = await importQuestions(file)
+ * console.log(`Imported ${result.imported}, skipped ${result.skipped}`)
+ * ```
+ */
 export async function importQuestions(file: File): Promise<ImportResult> {
   const text = await file.text()
   let raw: unknown[]
@@ -124,6 +173,11 @@ export async function importQuestions(file: File): Promise<ImportResult> {
   return result
 }
 
+/**
+ * Export selected questions (or all questions) to a JSON file download.
+ *
+ * @param ids - Optional array of question IDs to export. Exports all if omitted.
+ */
 export async function exportQuestions(ids?: string[]): Promise<void> {
   const questions = ids?.length
     ? await db.questions.bulkGet(ids).then(qs => qs.filter(Boolean) as Question[])
@@ -138,6 +192,10 @@ export async function exportQuestions(ids?: string[]): Promise<void> {
   URL.revokeObjectURL(url)
 }
 
+/**
+ * Download a small example questions file to help users understand the import format.
+ * Contains one question of each type: multiple choice, true/false, and open-ended.
+ */
 export function downloadExampleQuestions(): void {
   const example: Partial<Question>[] = [
     {

--- a/src/hooks/useBuzzer.ts
+++ b/src/hooks/useBuzzer.ts
@@ -3,29 +3,70 @@ import { db } from '@/db'
 import { transportManager } from '@/transport'
 import type { Game, BuzzEvent, GmDecision } from '@/db'
 
+/** Return value of {@link useBuzzer}. */
 export interface UseBuzzerResult {
+  /** All buzz events for the current question, sorted by timestamp ascending. */
   buzzes: BuzzEvent[]
-  /** Filtered for display — respects game.buzzDeduplication */
+  /**
+   * Filtered subset for display — respects `game.buzzDeduplication`.
+   * In `'firstOnly'` mode, only the first buzz per player is shown.
+   */
   displayBuzzes: BuzzEvent[]
+  /** Whether the buzzer is currently locked (mirrors `game.buzzerLocked`). */
   isLocked: boolean
+  /** Toggle the buzzer lock state and broadcast the change to players. */
   toggleLock: () => Promise<void>
+  /**
+   * Record an incoming buzz from the transport layer.
+   * Call this from the GM's transport event handler when a `BUZZ` event arrives.
+   */
   handleIncomingBuzz: (payload: {
     playerId: string
     playerName: string
     teamId: string | null
     timestamp: number
   }) => Promise<void>
+  /**
+   * Record the GM's ruling on a specific buzz.
+   * On `'Correct'`, awards points (if scoring is enabled) and optionally auto-locks.
+   */
   adjudicate: (buzzId: string, decision: GmDecision) => Promise<void>
+  /** Delete all buzz records for a question (e.g. when moving to the next question). */
   clearBuzzes: (questionId: string) => Promise<void>
 }
 
 /**
  * All buzzer logic for the GM side.
  *
- * - Receives incoming BUZZ transport events and writes BuzzEvents to DB.
- * - Handles false-start rules, deduplication, adjudication, and auto-lock.
- * - Does NOT subscribe to transport itself — caller feeds events via
- *   handleIncomingBuzz so GameMaster controls the single transport subscription.
+ * @remarks
+ * This hook does **not** subscribe to transport events itself — the caller is
+ * responsible for forwarding `BUZZ` events via `handleIncomingBuzz`. This keeps
+ * the single transport subscription in the GameMaster component and avoids
+ * duplicate registrations when the hook re-renders.
+ *
+ * **False-start handling:** If `game.allowFalseStarts` is `false`, buzzes that
+ * arrive while the buzzer is locked are silently ignored. If `true`, they are
+ * recorded with `isFalseStart: true` and shown in the GM's buzz list.
+ *
+ * **Auto-lock:** When `game.autoLockOnFirstCorrect` is `true`, the buzzer is
+ * locked automatically after the GM rules a buzz as `'Correct'`.
+ *
+ * **Scoring:** When `game.scoringEnabled` is `true`, a correct ruling increments
+ * the player's score by the difficulty point value of the current question.
+ *
+ * @param game - The active game record. Used for configuration flags and IDs.
+ * @param questionId - ID of the currently displayed question, or `null` if none.
+ *
+ * @example
+ * ```tsx
+ * const { displayBuzzes, toggleLock, adjudicate } = useBuzzer(game, currentQuestionId)
+ *
+ * useTransportEvents(useCallback(event => {
+ *   if (event.type === 'BUZZ') {
+ *     handleIncomingBuzz(event)
+ *   }
+ * }, [handleIncomingBuzz]))
+ * ```
  */
 export function useBuzzer(game: Game, questionId: string | null): UseBuzzerResult {
   const [buzzes, setBuzzes] = useState<BuzzEvent[]>([])
@@ -156,8 +197,14 @@ export function useBuzzer(game: Game, questionId: string | null): UseBuzzerResul
 }
 
 /**
- * Load existing buzz events for a question from DB.
- * Call this when question changes to hydrate useBuzzer's state.
+ * Load existing buzz events for a question from IndexedDB.
+ *
+ * @remarks
+ * Call this when the current question changes to hydrate `useBuzzer`'s local state.
+ * Results are sorted by timestamp ascending so the display order matches arrival order.
+ *
+ * @param questionId - The question whose buzz history to load.
+ * @returns Array of {@link BuzzEvent} records sorted by timestamp.
  */
 export async function loadBuzzesForQuestion(questionId: string): Promise<BuzzEvent[]> {
   return db.buzzEvents.where('questionId').equals(questionId).sortBy('timestamp')

--- a/src/hooks/useGameVisibility.ts
+++ b/src/hooks/useGameVisibility.ts
@@ -3,19 +3,55 @@ import { db } from '@/db'
 import { transportManager } from '@/transport'
 import type { Game } from '@/db'
 
+/** The three toggleable visibility flags for the current question. */
 export interface VisibilityState {
   showQuestion: boolean
   showAnswers: boolean
   showMedia: boolean
 }
 
+/** Return value of {@link useGameVisibility}. */
 export interface UseGameVisibilityResult {
+  /** Current visibility state — initialised from the game record. */
   visibility: VisibilityState
+  /**
+   * Toggle one visibility flag.
+   * Persists the change to IndexedDB and broadcasts a `VISIBILITY` transport event.
+   * On failure, reverts the optimistic local update.
+   */
   toggle: (key: keyof VisibilityState) => Promise<void>
+  /** `true` while the DB write is in flight. */
   saving: boolean
+  /** Non-null if the last `toggle` call failed. */
   error: string | null
 }
 
+/**
+ * Manages question-visibility state for the GM view.
+ *
+ * @remarks
+ * The GM can independently reveal the question text, answer options, and
+ * associated media to players. Each toggle is persisted to the `games` table
+ * and broadcast via the `VISIBILITY` transport event so all connected players
+ * update immediately.
+ *
+ * Optimistic updates are applied locally before the DB write completes.
+ * If the write fails, the previous state is restored and `error` is set.
+ *
+ * @param game - The active game. Initial visibility values are read from this record.
+ *
+ * @example
+ * ```tsx
+ * function VisibilityPanel({ game }: { game: Game }) {
+ *   const { visibility, toggle, saving } = useGameVisibility(game)
+ *   return (
+ *     <button onClick={() => toggle('showQuestion')} disabled={saving}>
+ *       {visibility.showQuestion ? 'Hide' : 'Show'} Question
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
 export function useGameVisibility(game: Game): UseGameVisibilityResult {
   const [visibility, setVisibility] = useState<VisibilityState>({
     showQuestion: game.showQuestion,

--- a/src/hooks/useScoreboard.ts
+++ b/src/hooks/useScoreboard.ts
@@ -3,30 +3,57 @@ import { db } from '@/db'
 import { transportManager } from '@/transport'
 import type { Game, Player, Team, DifficultyLevel } from '@/db'
 
+/** A single row in the scoreboard — either a team or an individual player. */
 export interface ScoreEntry {
   id: string
   name: string
   score: number
-  /** null for individual player when no team */
+  /** `null` for individual players not on a team. */
   teamId: string | null
-  /** Present for team rows; undefined for solo players */
+  /** Present for team rows; lists each member's individual score. */
   members?: { id: string; name: string; score: number }[]
   kind: 'player' | 'team'
 }
 
+/** Return value of {@link useScoreboard}. */
 export interface UseScoreboardResult {
+  /** Sorted list of scoreboard rows (descending by score). */
   entries: ScoreEntry[]
+  /**
+   * Apply a score delta to a player or team.
+   * Persists the change to IndexedDB and broadcasts a `SCORE_UPDATE` event.
+   */
   adjust: (id: string, kind: 'player' | 'team', delta: number) => Promise<void>
+  /** Suggested increment step — the lowest difficulty point value, or `1` if none configured. */
   defaultIncrement: number
 }
 
 /**
  * Manages scoreboard state for the GM view.
  *
- * - Loads players (and teams in team mode) from DB on mount.
- * - Provides `adjust` to apply manual +/- delta to a player or team.
- * - Emits SCORE_UPDATE after every adjustment so players see live scores.
- * - In team mode, aggregates player scores into team totals.
+ * @remarks
+ * - Loads players (and teams in team mode) from IndexedDB on mount.
+ * - Provides {@link UseScoreboardResult.adjust} to apply manual +/− delta to a player or team.
+ * - Emits a `SCORE_UPDATE` transport event after every adjustment so players see live scores.
+ * - In team mode, adjusting an individual player's score also recalculates and persists
+ *   the parent team's aggregate score.
+ * - Scores are clamped to a minimum of `0`.
+ *
+ * @param game - The active {@link Game} record. Only `game.id` is used for DB queries.
+ * @returns Sorted entries, the adjust callback, and a suggested increment step.
+ *
+ * @example
+ * ```tsx
+ * function Scoreboard({ game }: { game: Game }) {
+ *   const { entries, adjust, defaultIncrement } = useScoreboard(game)
+ *   return entries.map(e => (
+ *     <div key={e.id}>
+ *       {e.name}: {e.score}
+ *       <button onClick={() => adjust(e.id, e.kind, defaultIncrement)}>+</button>
+ *     </div>
+ *   ))
+ * }
+ * ```
  */
 export function useScoreboard(game: Game): UseScoreboardResult {
   const [players, setPlayers] = useState<Player[]>([])

--- a/src/hooks/useTransport.ts
+++ b/src/hooks/useTransport.ts
@@ -2,6 +2,34 @@ import { useEffect, useState, useCallback } from 'react'
 import { transportManager } from '@/transport'
 import type { TransportStatus, TransportType, TransportEvent } from '@/transport/types'
 
+/**
+ * Subscribe to the current transport connection status and expose a stable `send` callback.
+ *
+ * @remarks
+ * Wraps the module-level {@link transportManager} singleton so React components
+ * don't need to import it directly. Status updates trigger re-renders; `send`
+ * is memoised and never changes identity.
+ *
+ * @returns
+ * - `status` — current {@link TransportStatus} (`'idle'` when not connected).
+ * - `type` — active {@link TransportType} (`null` when not connected).
+ * - `send` — stable callback to dispatch a {@link TransportEvent} to the room.
+ *
+ * @example
+ * ```tsx
+ * function BuzzerButton() {
+ *   const { status, send } = useTransport()
+ *   return (
+ *     <button
+ *       disabled={status !== 'connected'}
+ *       onClick={() => send({ type: 'BUZZ', playerId, playerName, timestamp: Date.now() })}
+ *     >
+ *       Buzz!
+ *     </button>
+ *   )
+ * }
+ * ```
+ */
 export function useTransport() {
   const [status, setStatus] = useState<TransportStatus>(transportManager.status)
   const [type, setType] = useState<TransportType>(transportManager.transportType)
@@ -20,6 +48,25 @@ export function useTransport() {
   return { status, type, send }
 }
 
+/**
+ * Subscribe to incoming transport events without triggering re-renders.
+ *
+ * @remarks
+ * Registers `handler` with the transport singleton and unregisters it on
+ * unmount. The handler must be stable (wrap in `useCallback`) to avoid
+ * re-registering on every render.
+ *
+ * @param handler - Called for every {@link TransportEvent} received from the room.
+ *
+ * @example
+ * ```tsx
+ * useTransportEvents(
+ *   useCallback(event => {
+ *     if (event.type === 'BUZZER_LOCK') setLocked(true)
+ *   }, [])
+ * )
+ * ```
+ */
 export function useTransportEvents(handler: (event: TransportEvent) => void) {
   useEffect(() => {
     return transportManager.onEvent(handler)

--- a/src/transport/GunTransport.ts
+++ b/src/transport/GunTransport.ts
@@ -20,6 +20,30 @@ type GunNode = {
 
 const GUN_PEERS = ['https://gun-manhattan.herokuapp.com/gun', 'https://peer.wallie.io/gun']
 
+/**
+ * Relay-server transport implemented via Gun.js with SEA encryption.
+ *
+ * @remarks
+ * Gun.js is a decentralised, eventually-consistent graph database that uses
+ * public relay servers as a signalling and message-relay layer. Unlike PeerJS,
+ * it does not require a direct WebRTC connection between peers — all data flows
+ * through the relay, making it more reliable behind restrictive NATs and
+ * corporate firewalls.
+ *
+ * **Encryption:** Every event is symmetrically encrypted with
+ * [SEA](https://gun.eco/docs/SEA) (Security, Encryption, Authorization) using
+ * a shared secret derived from `passphrase` + `roomId` via `SEA.work()`. This
+ * prevents relay server operators or other Gun.js users from reading game data.
+ * The passphrase is displayed to players as part of the QR code payload.
+ *
+ * **Namespace:** Events are written to the Gun graph under the key
+ * `viktorani:<roomId>/events/<timestamp-random>`. Each event gets a unique
+ * key so Gun's CRDT merge does not overwrite previous entries.
+ *
+ * **Fallback role:** In `'auto'` mode, {@link TransportManager} instantiates
+ * this class only when {@link PeerJSTransport} fails — typically when the
+ * PeerJS cloud server is unreachable.
+ */
 export class GunTransport implements ITransport {
   private gun: GunInstance | null = null
   private room: GunNode | null = null

--- a/src/transport/GunTransport.ts
+++ b/src/transport/GunTransport.ts
@@ -40,8 +40,8 @@ const GUN_PEERS = ['https://gun-manhattan.herokuapp.com/gun', 'https://peer.wall
  * `viktorani:<roomId>/events/<timestamp-random>`. Each event gets a unique
  * key so Gun's CRDT merge does not overwrite previous entries.
  *
- * **Fallback role:** In `'auto'` mode, {@link TransportManager} instantiates
- * this class only when {@link PeerJSTransport} fails — typically when the
+ * **Fallback role:** In `'auto'` mode, {@link transport.TransportManager} instantiates
+ * this class only when {@link transport/PeerJSTransport.PeerJSTransport} fails — typically when the
  * PeerJS cloud server is unreachable.
  */
 export class GunTransport implements ITransport {

--- a/src/transport/PeerJSTransport.ts
+++ b/src/transport/PeerJSTransport.ts
@@ -18,8 +18,8 @@ const PREFIX = 'vkt-'
  * - **Player**: one `Peer` instance with a random ID; a single outbound
  *   `DataConnection` to the host.
  *
- * The 8-second timeout on `connect()` allows {@link TransportManager} to fall
- * back to {@link GunTransport} in `'auto'` mode when the PeerJS signalling
+ * The 8-second timeout on `connect()` allows {@link transport.TransportManager} to fall
+ * back to {@link transport/GunTransport.GunTransport} in `'auto'` mode when the PeerJS signalling
  * server is unreachable.
  */
 export class PeerJSTransport implements ITransport {

--- a/src/transport/PeerJSTransport.ts
+++ b/src/transport/PeerJSTransport.ts
@@ -4,6 +4,24 @@ import type { ITransport, TransportConfig, TransportEvent, TransportStatus } fro
 // PeerJS peer IDs are prefixed to avoid collisions with other apps
 const PREFIX = 'vkt-'
 
+/**
+ * WebRTC transport implemented via PeerJS.
+ *
+ * @remarks
+ * The host registers a deterministic PeerJS ID derived from the room code
+ * (`vkt-<roomId>`). Players connect to that well-known ID. All data flows
+ * over WebRTC data channels with DTLS encryption provided by the browser.
+ *
+ * Connection topology:
+ * - **Host**: one `Peer` instance listens for incoming connections; each
+ *   connected player gets its own `DataConnection` in `connections`.
+ * - **Player**: one `Peer` instance with a random ID; a single outbound
+ *   `DataConnection` to the host.
+ *
+ * The 8-second timeout on `connect()` allows {@link TransportManager} to fall
+ * back to {@link GunTransport} in `'auto'` mode when the PeerJS signalling
+ * server is unreachable.
+ */
 export class PeerJSTransport implements ITransport {
   private peer: Peer | null = null
   private connections: Map<string, DataConnection> = new Map()

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -15,7 +15,14 @@ export type { GameEvent, PlayerEvent, SerializedGameState } from './types'
 
 /**
  * Returns a cryptographically secure random integer in [0, max).
- * Uses crypto.getRandomValues() — available in all modern browsers and Node ≥ 15.
+ *
+ * @remarks
+ * Uses `crypto.getRandomValues()` — available in all modern browsers and Node ≥ 15.
+ * Unlike `Math.random()`, the output is suitable for security-sensitive operations
+ * such as passphrase generation.
+ *
+ * @param max - Upper bound (exclusive).
+ * @returns A random integer in the range `[0, max)`.
  */
 function secureRandomInt(max: number): number {
   const array = new Uint32Array(1)
@@ -58,10 +65,40 @@ const WORDS = [
   'quill',
 ]
 
+/**
+ * Generate a human-readable passphrase from random dictionary words.
+ *
+ * @remarks
+ * Used as the Gun.js SEA encryption key displayed to players via QR code
+ * so they don't need to type a hex string.
+ *
+ * @param wordCount - Number of words to include (default `4`).
+ * @returns A hyphen-separated passphrase, e.g. `'tiger-lamp-cloud-seven'`.
+ *
+ * @example
+ * ```ts
+ * const passphrase = generatePassphrase()   // 'ember-kite-coral-prism'
+ * const short = generatePassphrase(2)       // 'jade-drift'
+ * ```
+ */
 export function generatePassphrase(wordCount = 4): string {
   return Array.from({ length: wordCount }, () => WORDS[secureRandomInt(WORDS.length)]).join('-')
 }
 
+/**
+ * Generate a random 6-character room ID using an unambiguous character set.
+ *
+ * @remarks
+ * Characters `I`, `O`, `0`, and `1` are omitted to avoid visual confusion
+ * when reading codes aloud or from a small screen.
+ *
+ * @returns An uppercase alphanumeric string such as `'XK7RQZ'`.
+ *
+ * @example
+ * ```ts
+ * const roomId = generateRoomId() // 'XK7RQZ'
+ * ```
+ */
 export function generateRoomId(): string {
   const CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
   return Array.from({ length: 6 }, () => CHARS[secureRandomInt(CHARS.length)]).join('')
@@ -71,18 +108,55 @@ export function generateRoomId(): string {
 
 type StatusListener = (status: TransportStatus, type: TransportType) => void
 
+/**
+ * Facade over {@link PeerJSTransport} and {@link GunTransport} that handles
+ * mode selection, automatic fallback, and event fan-out.
+ *
+ * @remarks
+ * Instantiated as a module-level singleton (`transportManager`). Components
+ * and hooks interact with the transport exclusively through this class —
+ * never by constructing transport instances directly.
+ *
+ * **Mode selection** (`config.mode`):
+ * - `'peer'` — use PeerJS only.
+ * - `'gun'`  — use Gun.js only.
+ * - `'auto'` — try PeerJS; if it fails within the timeout, fall back to Gun.js.
+ *
+ * @example
+ * ```ts
+ * await transportManager.connect({ mode: 'auto', role: 'host', roomId, passphrase })
+ * const unsub = transportManager.onEvent(event => console.log(event))
+ * transportManager.send({ type: 'BUZZER_LOCK' })
+ * unsub()
+ * await transportManager.disconnect()
+ * ```
+ */
 export class TransportManager {
   private transport: ITransport | null = null
   private statusListeners: StatusListener[] = []
   private eventHandlers: Array<(e: TransportEvent) => void> = []
 
+  /** Current connection lifecycle state. `'idle'` when not connected. */
   get status(): TransportStatus {
     return this.transport?.status ?? 'idle'
   }
+
+  /** Which concrete transport is active, or `null` when not connected. */
   get transportType(): TransportType {
     return this.transport?.transportType ?? null
   }
 
+  /**
+   * Connect to (or create) a room using the specified configuration.
+   *
+   * @remarks
+   * Any existing connection is cleanly disconnected before the new one starts.
+   * All previously registered event handlers are preserved — they will receive
+   * events from the new connection without needing to re-subscribe.
+   *
+   * @param config - Room credentials and transport mode.
+   * @throws If the selected transport fails to connect (non-`'auto'` modes only).
+   */
   async connect(config: TransportConfig): Promise<void> {
     await this.disconnect()
 
@@ -113,16 +187,48 @@ export class TransportManager {
     this.transport = t
   }
 
+  /**
+   * Disconnect from the current room and release all transport resources.
+   *
+   * @remarks
+   * Safe to call when not connected — it is a no-op in that case.
+   * Status listeners are notified after disconnection.
+   */
   async disconnect(): Promise<void> {
     this.transport?.disconnect()
     this.transport = null
     this.notifyStatus()
   }
 
+  /**
+   * Send an event to all peers in the room.
+   *
+   * @remarks
+   * Silently drops the event if not currently connected. Callers do not
+   * need to guard against the disconnected state.
+   *
+   * @param event - Any {@link TransportEvent} variant.
+   */
   send(event: TransportEvent) {
     this.transport?.send(event)
   }
 
+  /**
+   * Subscribe to incoming transport events.
+   *
+   * @param handler - Invoked for every event received from the room.
+   * @returns An unsubscribe function. Call it in a `useEffect` cleanup or
+   *          component teardown to avoid memory leaks.
+   *
+   * @example
+   * ```ts
+   * useEffect(() => {
+   *   return transportManager.onEvent(event => {
+   *     if (event.type === 'BUZZ') handleBuzz(event)
+   *   })
+   * }, [])
+   * ```
+   */
   onEvent(handler: (e: TransportEvent) => void): () => void {
     this.eventHandlers.push(handler)
     return () => {
@@ -130,6 +236,12 @@ export class TransportManager {
     }
   }
 
+  /**
+   * Subscribe to connection status changes.
+   *
+   * @param listener - Called whenever `status` or `transportType` changes.
+   * @returns An unsubscribe function.
+   */
   onStatusChange(listener: StatusListener): () => void {
     this.statusListeners.push(listener)
     return () => {
@@ -142,5 +254,5 @@ export class TransportManager {
   }
 }
 
-// Singleton instance
+/** Module-level singleton — import and use this directly rather than instantiating. */
 export const transportManager = new TransportManager()

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -106,7 +106,8 @@ export function generateRoomId(): string {
 
 // ── Manager ───────────────────────────────────────────────────────────────────
 
-type StatusListener = (status: TransportStatus, type: TransportType) => void
+/** Callback invoked when the transport connection status or type changes. */
+export type StatusListener = (status: TransportStatus, type: TransportType) => void
 
 /**
  * Facade over {@link PeerJSTransport} and {@link GunTransport} that handles

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -77,7 +77,7 @@ export interface SerializedGameState {
 }
 
 /**
- * Configuration passed to {@link ITransport.connect}.
+ * Configuration passed to {@link transport/types.ITransport.connect}.
  *
  * @remarks
  * `passphrase` is used by Gun.js SEA for symmetric encryption of the
@@ -104,7 +104,7 @@ export type TransportType = 'peer' | 'gun' | null
 // ── Interface all transports must implement ───────────────────────────────────
 
 /**
- * Common interface implemented by {@link PeerJSTransport} and {@link GunTransport}.
+ * Common interface implemented by {@link transport/PeerJSTransport.PeerJSTransport} and {@link transport/GunTransport.GunTransport}.
  *
  * @remarks
  * All transports are one-room-per-instance. Call `connect()` once per session;

--- a/src/transport/types.ts
+++ b/src/transport/types.ts
@@ -1,26 +1,69 @@
 // ── Shared event types ────────────────────────────────────────────────────────
 
+/**
+ * Events broadcast by the GameMaster to all connected players.
+ *
+ * @remarks
+ * All variants are discriminated by `type`. Consumers should switch on `type`
+ * and handle only the variants they care about.
+ *
+ * @example
+ * ```ts
+ * transport.onEvent(event => {
+ *   if (event.type === 'SLIDE_CHANGE') {
+ *     goToSlide(event.index)
+ *   }
+ * })
+ * ```
+ */
 export type GameEvent =
+  /** Instructs players to navigate to a specific question within a round. */
   | { type: 'SLIDE_CHANGE'; index: number; roundIndex: number }
+  /** Locks the buzzer — no new buzzes are accepted. */
   | { type: 'BUZZER_LOCK' }
+  /** Unlocks the buzzer — players may buzz in. */
   | { type: 'BUZZER_UNLOCK' }
+  /** Updated score map keyed by player or team ID. */
   | { type: 'SCORE_UPDATE'; scores: Record<string, number> }
+  /** Starts a new countdown timer visible to players. */
   | { type: 'TIMER_START'; id: string; duration: number; label: string }
+  /** Pauses the named timer. */
   | { type: 'TIMER_PAUSE'; id: string }
+  /** Resumes the named timer from its paused position. */
   | { type: 'TIMER_RESUME'; id: string }
+  /** Notifies players that a timer has reached zero. */
   | { type: 'TIMER_EXPIRED'; id: string; label: string }
+  /** Full game-state snapshot sent to newly connected players. */
   | { type: 'GAME_STATE'; state: SerializedGameState }
+  /** Toggles which parts of the current question are revealed to players. */
   | { type: 'VISIBILITY'; showQuestion: boolean; showAnswers: boolean; showMedia: boolean }
+  /** Lifecycle status of the game session. */
   | { type: 'GAME_STATUS'; status: 'active' | 'paused' | 'ended' }
 
+/**
+ * Events sent by players to the GameMaster.
+ *
+ * @remarks
+ * The host listens for these via `transportManager.onEvent()` and dispatches
+ * them to the appropriate hook (e.g. `useBuzzer.handleIncomingBuzz`).
+ */
 export type PlayerEvent =
+  /** Player pressed the buzzer. `timestamp` is a `performance.now()` value for ordering. */
   | { type: 'BUZZ'; playerId: string; playerName: string; timestamp: number }
+  /** Player joined the lobby. `deviceId` is a stable browser-local UUID. */
   | { type: 'JOIN'; playerId: string; playerName: string; teamId: string | null; deviceId: string }
+  /** Player disconnected or left the game. */
   | { type: 'LEAVE'; playerId: string }
+  /** Player's tab visibility changed — used to flag distracted players. */
   | { type: 'FOCUS_CHANGE'; playerId: string; away: boolean }
 
+/** Union of all events that flow through the transport layer. */
 export type TransportEvent = GameEvent | PlayerEvent
 
+/**
+ * Minimal game-state snapshot sent to players on join so they can
+ * render the current question, scores, and buzzer state without DB access.
+ */
 export interface SerializedGameState {
   gameId: string
   status: string
@@ -33,24 +76,66 @@ export interface SerializedGameState {
   scores: Record<string, number>
 }
 
+/**
+ * Configuration passed to {@link ITransport.connect}.
+ *
+ * @remarks
+ * `passphrase` is used by Gun.js SEA for symmetric encryption of the
+ * Gun node key. PeerJS ignores it — PeerJS connections are encrypted by
+ * the underlying WebRTC DTLS handshake.
+ */
 export interface TransportConfig {
+  /** Which transport to use. `'auto'` tries PeerJS first, falls back to Gun.js. */
   mode: 'auto' | 'peer' | 'gun'
+  /** `'host'` creates the room; `'player'` joins an existing room. */
   role: 'host' | 'player'
+  /** Six-character uppercase room code (e.g. `'XK7RQZ'`). */
   roomId: string
-  passphrase: string // used by Gun SEA; ignored by PeerJS
+  /** Four-word passphrase used by Gun SEA encryption (e.g. `'tiger-lamp-cloud-seven'`). */
+  passphrase: string
 }
 
+/** Lifecycle state of the underlying transport connection. */
 export type TransportStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error'
+
+/** Which transport implementation is currently active, or `null` if not connected. */
 export type TransportType = 'peer' | 'gun' | null
 
 // ── Interface all transports must implement ───────────────────────────────────
 
+/**
+ * Common interface implemented by {@link PeerJSTransport} and {@link GunTransport}.
+ *
+ * @remarks
+ * All transports are one-room-per-instance. Call `connect()` once per session;
+ * call `disconnect()` before switching rooms or transport modes.
+ */
 export interface ITransport {
+  /** Current connection lifecycle state. */
   readonly status: TransportStatus
+  /** Which concrete transport is active. */
   readonly transportType: TransportType
 
+  /**
+   * Establish a connection to (or create) the specified room.
+   * @param config - Room credentials and mode selection.
+   * @returns Resolves when the connection is ready to send and receive events.
+   */
   connect(config: TransportConfig): Promise<void>
+
+  /** Tear down the connection and release all resources. */
   disconnect(): void
+
+  /**
+   * Send an event to the other side of the connection.
+   * @param event - Any {@link TransportEvent} variant.
+   */
   send(event: TransportEvent): void
+
+  /**
+   * Subscribe to incoming events.
+   * @param handler - Called for every event received.
+   * @returns An unsubscribe function — call it to stop receiving events.
+   */
   onEvent(handler: (event: TransportEvent) => void): () => void
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -15,7 +15,5 @@
   "name": "Viktorani API",
   "readme": "none",
   "includeVersion": true,
-  "disableSources": false,
-  "suppressCommentWarningsInDeclarationFiles": true,
-  "plugin": ["typedoc-plugin-markdown"]
+  "disableSources": false
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPointStrategy": "expand",
+  "entryPoints": ["src/transport", "src/db", "src/hooks"],
+  "exclude": ["src/test/**", "src/pages/**", "src/components/**", "**/*.test.*"],
+  "out": "docs/api",
+  "name": "Viktorani API",
+  "readme": "none",
+  "includeVersion": true,
+  "disableSources": false,
+  "plugin": ["typedoc-plugin-markdown"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,11 +2,20 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPointStrategy": "expand",
   "entryPoints": ["src/transport", "src/db", "src/hooks"],
-  "exclude": ["src/test/**", "src/pages/**", "src/components/**", "**/*.test.*"],
+  "exclude": [
+    "src/test/**",
+    "src/pages/**",
+    "src/components/**",
+    "**/*.test.*",
+    "src/hooks/useNavigation.ts",
+    "src/hooks/useKeyNav.ts",
+    "src/hooks/useLocalStorage.ts"
+  ],
   "out": "docs/api",
   "name": "Viktorani API",
   "readme": "none",
   "includeVersion": true,
   "disableSources": false,
+  "suppressCommentWarningsInDeclarationFiles": true,
   "plugin": ["typedoc-plugin-markdown"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        // Prevent the service worker from intercepting requests to the
+        // TypeDoc API docs deployed at /viktorani/api/
+        navigateFallbackDenylist: [/^\/viktorani\/api\//],
       },
     }),
   ],
@@ -44,8 +47,6 @@ export default defineConfig({
       exclude: [
         'node_modules/',
         'dist/',
-        'archive/',
-        'deploy/',
         'src/main.tsx',
         'src/pages/**', // page-level integration — tested via e2e
         'src/components/AdminLayout.tsx',


### PR DESCRIPTION
## Goal

Raise documentation quality across three dimensions:

1. **Code documentation** — TypeDoc generates and publishes API docs automatically on every push to `master`; no manual maintenance needed.
2. **User guide** — end-to-end usage docs with concrete examples for host and player flows, covering online and offline scenarios.
3. **Architecture docs** — ADR backlog for decisions already made but not yet recorded.

## Acceptance criteria

- [ ] `npm run docs` produces `docs/api/` with no errors
- [ ] API docs publish automatically to `https://morbeo.github.io/viktorani/api/` on every push to `master`
- [ ] All exported hooks, transport types, and DB helpers have TSDoc comments
- [ ] `docs/user-guide/host.md` covers question bank setup, game creation, GM controls, buzzer, timer, and scoring
- [ ] `docs/user-guide/player.md` covers joining, online play, and the offline/no-device scenario
- [ ] Five ADRs written for: transport selection, Dexie migrations, PWA strategy, tag-only classification, Vitest vmForks pool
- [ ] README links to API docs and user guides