### PR TITLE
feat(ui): add Lucide React icon set across all screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dexie-react-hooks": "^4.4.0",
         "fuse.js": "^7.3.0",
         "gun": "^0.2020.1241",
+        "lucide-react": "^0.468.0",
         "peerjs": "^1.5.5",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
@@ -8331,6 +8332,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.468.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
+      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/lunr": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viktorani",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "viktorani",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -26,6 +26,7 @@
     "fuse.js": "^7.3.0",
     "gun": "^0.2020.1241",
     "peerjs": "^1.5.5",
+    "lucide-react": "^0.468.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/components/AdminLayout.tsx
+++ b/src/components/AdminLayout.tsx
@@ -1,18 +1,30 @@
 import { NavLink } from 'react-router-dom'
 import type { ReactNode } from 'react'
+import {
+  LayoutDashboard,
+  CircleHelp,
+  Trophy,
+  NotebookPen,
+  Settings,
+  Users,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
+import { Icon } from '@/components/ui'
 
 interface Props {
   children: ReactNode
   title?: string
 }
 
-const nav = [
-  { to: '/admin', label: 'Dashboard', icon: '◈' },
-  { to: '/admin/questions', label: 'Questions', icon: '?' },
-  { to: '/admin/games', label: 'Games', icon: '▶' },
-  { to: '/admin/notes', label: 'Notes', icon: '✎' },
-  { to: '/admin/settings', label: 'Settings', icon: '⚙' },
+const nav: { to: string; label: string; icon: LucideIcon }[] = [
+  { to: '/admin', label: 'Dashboard', icon: LayoutDashboard },
+  { to: '/admin/questions', label: 'Questions', icon: CircleHelp },
+  { to: '/admin/games', label: 'Games', icon: Trophy },
+  { to: '/admin/notes', label: 'Notes', icon: NotebookPen },
+  { to: '/admin/settings', label: 'Settings', icon: Settings },
 ]
 
 export default function AdminLayout({ children, title }: Props) {
@@ -53,6 +65,7 @@ export default function AdminLayout({ children, title }: Props) {
           )}
           <button
             onClick={() => setCollapsed(c => !c)}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
             className="flex items-center justify-center rounded transition-all hover:bg-black/5"
             style={{
               color: 'var(--color-muted)',
@@ -60,11 +73,9 @@ export default function AdminLayout({ children, title }: Props) {
               height: 28,
               flexShrink: 0,
               marginLeft: collapsed ? 0 : 8,
-              fontSize: 14,
             }}
-            title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
-            {collapsed ? '›' : '‹'}
+            <Icon icon={collapsed ? ChevronRight : ChevronLeft} size="sm" />
           </button>
         </div>
 
@@ -89,7 +100,7 @@ export default function AdminLayout({ children, title }: Props) {
                 background: isActive ? 'var(--color-gold-light)' : undefined,
               })}
             >
-              <span className="text-base w-5 text-center shrink-0">{icon}</span>
+              <Icon icon={icon} size={collapsed ? 'md' : 'sm'} className="shrink-0" />
               {!collapsed && label}
             </NavLink>
           ))}
@@ -105,7 +116,7 @@ export default function AdminLayout({ children, title }: Props) {
             }`}
             style={{ color: 'var(--color-muted)', borderColor: 'var(--color-border)' }}
           >
-            <span className="text-base w-5 text-center shrink-0">⊕</span>
+            <Icon icon={Users} size={collapsed ? 'md' : 'sm'} className="shrink-0" />
             {!collapsed && 'Player view'}
           </a>
         </div>

--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -1,3 +1,5 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { Icon } from '@/components/ui'
 import type { NavPosition } from '@/pages/admin/gamemaster-utils'
 
 interface NavHeaderProps {
@@ -29,7 +31,7 @@ export function NavHeader({ pos, totalQ, onPrev, onNext }: NavHeaderProps) {
         className="w-8 h-8 rounded flex items-center justify-center transition-all hover:bg-black/5 disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
         style={{ color: 'var(--color-ink)' }}
       >
-        ←
+        <Icon icon={ChevronLeft} size="md" />
       </button>
 
       {/* Centre: label + progress */}
@@ -70,7 +72,7 @@ export function NavHeader({ pos, totalQ, onPrev, onNext }: NavHeaderProps) {
         className="w-8 h-8 rounded flex items-center justify-center transition-all hover:bg-black/5 disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
         style={{ color: 'var(--color-ink)' }}
       >
-        →
+        <Icon icon={ChevronRight} size="md" />
       </button>
     </div>
   )

--- a/src/components/buzzer/BuzzList.tsx
+++ b/src/components/buzzer/BuzzList.tsx
@@ -1,5 +1,6 @@
+import { CircleCheck, CircleX, Ban, TriangleAlert } from 'lucide-react'
 import type { BuzzEvent, GmDecision } from '@/db'
-import { Button } from '@/components/ui'
+import { Button, Icon } from '@/components/ui'
 
 interface BuzzListProps {
   buzzes: BuzzEvent[]
@@ -101,9 +102,10 @@ export function BuzzList({ buzzes, allBuzzes, onAdjudicate, showAll }: BuzzListP
 
                 {buzz.isFalseStart && (
                   <span
-                    className="text-xs px-1.5 py-0.5 rounded font-medium"
+                    className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded font-medium"
                     style={{ background: 'var(--color-gold)22', color: 'var(--color-gold)' }}
                   >
+                    <Icon icon={TriangleAlert} size="sm" />
                     False Start
                   </span>
                 )}
@@ -139,6 +141,7 @@ export function BuzzList({ buzzes, allBuzzes, onAdjudicate, showAll }: BuzzListP
                 <Button
                   size="sm"
                   onClick={() => onAdjudicate(buzz.id, 'Correct')}
+                  aria-label="Mark correct"
                   style={{
                     background: 'var(--color-green)',
                     color: '#fff',
@@ -147,11 +150,12 @@ export function BuzzList({ buzzes, allBuzzes, onAdjudicate, showAll }: BuzzListP
                   }}
                   title="Mark correct"
                 >
-                  ✓
+                  <Icon icon={CircleCheck} size="sm" />
                 </Button>
                 <Button
                   size="sm"
                   onClick={() => onAdjudicate(buzz.id, 'Incorrect')}
+                  aria-label="Mark incorrect"
                   style={{
                     background: 'var(--color-red)',
                     color: '#fff',
@@ -160,16 +164,18 @@ export function BuzzList({ buzzes, allBuzzes, onAdjudicate, showAll }: BuzzListP
                   }}
                   title="Mark incorrect"
                 >
-                  ✗
+                  <Icon icon={CircleX} size="sm" />
                 </Button>
                 <Button
                   size="sm"
                   variant="ghost"
                   onClick={() => onAdjudicate(buzz.id, 'Skip')}
+                  aria-label="Skip buzz"
                   style={{ minHeight: 36, minWidth: 36 }}
                   title="Skip"
                 >
-                  ⊘
+                  <Icon icon={Ban} size="sm" />
+                  <span>Skip</span>
                 </Button>
               </div>
             )}

--- a/src/components/buzzer/BuzzerLockButton.tsx
+++ b/src/components/buzzer/BuzzerLockButton.tsx
@@ -1,3 +1,6 @@
+import { Lock, LockOpen } from 'lucide-react'
+import { Icon } from '@/components/ui'
+
 interface BuzzerLockButtonProps {
   isLocked: boolean
   onToggle: () => void
@@ -25,7 +28,7 @@ export function BuzzerLockButton({ isLocked, onToggle, disabled }: BuzzerLockBut
         cursor: disabled ? 'not-allowed' : 'pointer',
       }}
     >
-      <span style={{ fontSize: 20 }}>{isLocked ? '🔒' : '🔓'}</span>
+      <Icon icon={isLocked ? Lock : LockOpen} size="md" />
       <span>{isLocked ? 'Buzzer Locked' : 'Buzzer Open'}</span>
     </button>
   )

--- a/src/components/buzzer/BuzzerPanel.tsx
+++ b/src/components/buzzer/BuzzerPanel.tsx
@@ -1,6 +1,7 @@
+import { Eraser } from 'lucide-react'
 import { BuzzerLockButton } from './BuzzerLockButton'
 import { BuzzList } from './BuzzList'
-import { Button } from '@/components/ui'
+import { Button, Icon } from '@/components/ui'
 import type { Game, BuzzEvent, GmDecision } from '@/db'
 
 interface BuzzerPanelProps {
@@ -50,6 +51,7 @@ export function BuzzerPanel({
               title="Clear all buzzes for this question"
               style={{ color: 'var(--color-muted)' }}
             >
+              <Icon icon={Eraser} size="sm" />
               Clear buzzes
             </Button>
           )}

--- a/src/components/host/HostQuestionHeader.tsx
+++ b/src/components/host/HostQuestionHeader.tsx
@@ -1,5 +1,8 @@
 import type { Question, GameQuestion } from '@/db'
 import { Badge } from '@/components/ui'
+import { Icon } from '@/components/ui'
+import { ListChecks, ToggleLeft, PencilLine } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 
 const TYPE_LABEL: Record<Question['type'], string> = {
   multiple_choice: 'Multiple choice',
@@ -11,6 +14,12 @@ const TYPE_COLOR: Record<Question['type'], string> = {
   multiple_choice: '#2563eb',
   true_false: '#7c3aed',
   open_ended: '#0891b2',
+}
+
+const TYPE_ICON: Record<Question['type'], LucideIcon> = {
+  multiple_choice: ListChecks,
+  true_false: ToggleLeft,
+  open_ended: PencilLine,
 }
 
 const STATUS_LABEL: Record<GameQuestion['status'], string> = {
@@ -37,6 +46,7 @@ export function HostQuestionHeader({ question, gameQuestion }: HostQuestionHeade
     <div className="flex flex-col gap-3">
       <div className="flex items-center gap-2 flex-wrap">
         <Badge color={TYPE_COLOR[question.type]} style={{ color: '#fff' }}>
+          <Icon icon={TYPE_ICON[question.type]} size="sm" className="mr-1" />
           {TYPE_LABEL[question.type]}
         </Badge>
         <Badge color={STATUS_COLOR[gameQuestion.status]} style={{ color: '#fff' }}>

--- a/src/components/scoreboard/ScoreboardPanel.tsx
+++ b/src/components/scoreboard/ScoreboardPanel.tsx
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react'
+import { Plus, Minus, ChevronDown, ChevronRight, Medal } from 'lucide-react'
 import { useScoreboard } from '@/hooks/useScoreboard'
+import { Icon } from '@/components/ui'
 import type { Game } from '@/db'
 
 interface FlashState {
@@ -102,12 +104,16 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                     transition: 'background 0.15s ease',
                   }}
                 >
-                  {/* Rank */}
+                  {/* Rank — medal for first place */}
                   <span
-                    className="w-5 text-center text-xs font-bold shrink-0"
+                    className="w-5 text-center text-xs font-bold shrink-0 flex items-center justify-center"
                     style={{ color: rank === 0 ? 'var(--color-gold)' : 'var(--color-muted)' }}
                   >
-                    {rank + 1}
+                    {rank === 0 ? (
+                      <Icon icon={Medal} size="sm" className="text-[var(--color-gold)]" />
+                    ) : (
+                      rank + 1
+                    )}
                   </span>
 
                   {/* Name + expand toggle */}
@@ -126,16 +132,12 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                     }
                   >
                     {hasMembers && (
-                      <span
-                        className="text-xs shrink-0 transition-transform"
-                        style={{
-                          color: 'var(--color-muted)',
-                          transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)',
-                          display: 'inline-block',
-                        }}
-                      >
-                        ▶
-                      </span>
+                      <Icon
+                        icon={isExpanded ? ChevronDown : ChevronRight}
+                        size="sm"
+                        className="shrink-0 transition-transform"
+                        aria-hidden={true}
+                      />
                     )}
                     <span className="truncate">{entry.name}</span>
                     {entry.kind === 'team' && (
@@ -172,7 +174,7 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                   {/* Adjust buttons */}
                   <div className="flex items-center gap-1 shrink-0">
                     <button
-                      className="w-7 h-7 rounded flex items-center justify-center text-base font-bold transition-colors"
+                      className="w-7 h-7 rounded flex items-center justify-center transition-colors"
                       style={{
                         background: 'var(--color-red)18',
                         color: 'var(--color-red)',
@@ -180,10 +182,10 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                       onClick={() => void handleAdjust(entry.id, entry.kind, -defaultIncrement)}
                       aria-label={`Subtract ${defaultIncrement} from ${entry.name}`}
                     >
-                      −
+                      <Icon icon={Minus} size="sm" />
                     </button>
                     <button
-                      className="w-7 h-7 rounded flex items-center justify-center text-base font-bold transition-colors"
+                      className="w-7 h-7 rounded flex items-center justify-center transition-colors"
                       style={{
                         background: 'var(--color-green)18',
                         color: 'var(--color-green)',
@@ -191,7 +193,7 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                       onClick={() => void handleAdjust(entry.id, entry.kind, +defaultIncrement)}
                       aria-label={`Add ${defaultIncrement} to ${entry.name}`}
                     >
-                      +
+                      <Icon icon={Plus} size="sm" />
                     </button>
                   </div>
                 </div>
@@ -243,7 +245,7 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                           </span>
                           <div className="flex items-center gap-1 shrink-0">
                             <button
-                              className="w-6 h-6 rounded flex items-center justify-center text-sm font-bold"
+                              className="w-6 h-6 rounded flex items-center justify-center"
                               style={{
                                 background: 'var(--color-red)18',
                                 color: 'var(--color-red)',
@@ -253,10 +255,10 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                               }
                               aria-label={`Subtract ${defaultIncrement} from ${member.name}`}
                             >
-                              −
+                              <Icon icon={Minus} size="sm" />
                             </button>
                             <button
-                              className="w-6 h-6 rounded flex items-center justify-center text-sm font-bold"
+                              className="w-6 h-6 rounded flex items-center justify-center"
                               style={{
                                 background: 'var(--color-green)18',
                                 color: 'var(--color-green)',
@@ -266,7 +268,7 @@ export function ScoreboardPanel({ game }: ScoreboardPanelProps) {
                               }
                               aria-label={`Add ${defaultIncrement} to ${member.name}`}
                             >
-                              +
+                              <Icon icon={Plus} size="sm" />
                             </button>
                           </div>
                         </div>

--- a/src/components/timer/TimerCard.tsx
+++ b/src/components/timer/TimerCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
-import { Button } from '@/components/ui'
+import { Play, Pause, RotateCcw, SlidersHorizontal, Trash2, Bell, Eye } from 'lucide-react'
+import { Button, Icon } from '@/components/ui'
 import { formatTime } from '@/hooks/useTimer'
 import type { Timer } from '@/db'
 
@@ -78,6 +79,9 @@ export function TimerCard({
   const hasVisual = timer.visualNotify !== 'none'
   const hasAutoReset = timer.autoReset !== 'none'
 
+  const toggleIcon = isRunning ? Pause : Play
+  const toggleLabel = isRunning ? 'Pause' : isNeverStarted ? 'Start' : 'Resume'
+
   return (
     <div
       className="rounded-xl border flex items-center gap-4 px-4 py-3"
@@ -109,29 +113,32 @@ export function TimerCard({
           </p>
           {hasAudio && (
             <span
-              className="text-xs px-1.5 py-0.5 rounded-full"
+              className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full"
               style={{ background: 'var(--color-gold)22', color: 'var(--color-gold)' }}
               title={`Audio: ${timer.audioNotify}`}
             >
-              🔔 {timer.audioNotify}
+              <Icon icon={Bell} size="sm" />
+              {timer.audioNotify}
             </span>
           )}
           {hasVisual && (
             <span
-              className="text-xs px-1.5 py-0.5 rounded-full"
+              className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full"
               style={{ background: 'var(--color-gold)22', color: 'var(--color-gold)' }}
               title={`Visual: ${timer.visualNotify}`}
             >
-              👁 {timer.visualNotify}
+              <Icon icon={Eye} size="sm" />
+              {timer.visualNotify}
             </span>
           )}
           {hasAutoReset && (
             <span
-              className="text-xs px-1.5 py-0.5 rounded-full"
+              className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full"
               style={{ background: 'var(--color-border)', color: 'var(--color-muted)' }}
               title={`Auto-reset: ${timer.autoReset}`}
             >
-              ↺ {timer.autoReset}
+              <Icon icon={RotateCcw} size="sm" />
+              {timer.autoReset}
             </span>
           )}
         </div>
@@ -143,36 +150,40 @@ export function TimerCard({
           size="sm"
           variant={isRunning ? 'secondary' : 'primary'}
           onClick={handleToggle}
-          title={isRunning ? 'Pause' : isNeverStarted ? 'Start' : 'Resume'}
+          title={toggleLabel}
+          aria-label={toggleLabel}
         >
-          {isRunning ? '⏸' : '▶'}
+          <Icon icon={toggleIcon} size="sm" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
           onClick={onRestart}
           title="Restart"
+          aria-label="Restart timer"
           style={{ color: 'var(--color-muted)' }}
         >
-          ↺
+          <Icon icon={RotateCcw} size="sm" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
           onClick={onEdit}
           title="Timer settings"
+          aria-label="Timer settings"
           style={{ color: 'var(--color-muted)' }}
         >
-          ⚙
+          <Icon icon={SlidersHorizontal} size="sm" />
         </Button>
         <Button
           size="sm"
           variant="ghost"
           onClick={onDelete}
           title="Delete timer"
+          aria-label="Delete timer"
           style={{ color: 'var(--color-muted)' }}
         >
-          ✕
+          <Icon icon={Trash2} size="sm" />
         </Button>
       </div>
     </div>

--- a/src/components/timer/TimerExpiredOverlay.tsx
+++ b/src/components/timer/TimerExpiredOverlay.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { AlarmClock } from 'lucide-react'
+import { Icon } from '@/components/ui'
 
 interface TimerExpiredOverlayProps {
   label: string
@@ -77,8 +79,8 @@ export function TimerExpiredOverlay({
             transform="rotate(-90 24 24)"
           />
         </svg>
-        <span className="absolute text-3xl" role="img" aria-label="alarm">
-          ⏰
+        <span className="absolute flex items-center justify-center" style={{ color: '#fff' }}>
+          <Icon icon={AlarmClock} size="md" aria-hidden={false} aria-label="alarm" />
         </span>
       </div>
 

--- a/src/components/timer/TimerPanel.tsx
+++ b/src/components/timer/TimerPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react'
-import { Button } from '@/components/ui'
+import { Plus, PauseCircle, PlayCircle, RotateCcw, Trash2 } from 'lucide-react'
+import { Button, Icon } from '@/components/ui'
 import { TimerCard } from './TimerCard'
 import { CreateTimerModal } from './CreateTimerModal'
 import { EditTimerModal } from './EditTimerModal'
@@ -110,30 +111,42 @@ export function TimerPanel({ gameId, hook }: TimerPanelProps) {
                   size="sm"
                   variant="ghost"
                   onClick={handlePauseResumeAll}
+                  aria-label={allPaused ? 'Resume all timers' : 'Pause all timers'}
                   style={{ color: 'var(--color-muted)' }}
                 >
+                  <Icon icon={allPaused ? PlayCircle : PauseCircle} size="sm" />
                   {allPaused ? 'Resume all' : 'Pause all'}
                 </Button>
                 <Button
                   size="sm"
                   variant="ghost"
                   onClick={restartAll}
+                  aria-label="Restart all timers"
                   style={{ color: 'var(--color-muted)' }}
                 >
+                  <Icon icon={RotateCcw} size="sm" />
                   Restart all
                 </Button>
                 <Button
                   size="sm"
                   variant="ghost"
                   onClick={deleteAll}
+                  aria-label="Clear all timers"
                   style={{ color: 'var(--color-muted)' }}
                 >
+                  <Icon icon={Trash2} size="sm" />
                   Clear all
                 </Button>
               </>
             )}
-            <Button size="sm" variant="primary" onClick={() => setShowCreate(true)}>
-              + Timer
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => setShowCreate(true)}
+              aria-label="Add timer"
+            >
+              <Icon icon={Plus} size="sm" />
+              Timer
             </Button>
           </div>
         </div>

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from 'lucide-react'
+
+/**
+ * Thin wrapper around Lucide icons that enforces project-wide size and
+ * stroke-width conventions:
+ *
+ *   sm (16px) — inline with text, badges, compact rows
+ *   md (20px) — standalone buttons, collapsed-sidebar nav
+ */
+
+interface IconProps {
+  icon: LucideIcon
+  /** sm = 16px (inline), md = 20px (standalone). Default: sm */
+  size?: 'sm' | 'md'
+  className?: string
+  'aria-hidden'?: boolean
+  'aria-label'?: string
+}
+
+export function Icon({
+  icon: LucideComponent,
+  size = 'sm',
+  className = '',
+  'aria-hidden': ariaHidden = true,
+  'aria-label': ariaLabel,
+}: IconProps) {
+  const px = size === 'md' ? 20 : 16
+  return (
+    <LucideComponent
+      size={px}
+      strokeWidth={1.75}
+      className={className}
+      aria-hidden={ariaHidden}
+      aria-label={ariaLabel}
+    />
+  )
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -1,4 +1,9 @@
 import type { ReactNode, ButtonHTMLAttributes, InputHTMLAttributes } from 'react'
+import { X, Network, Radio, CircleDot, CircleOff } from 'lucide-react'
+import { Icon } from './Icon'
+import type { TransportStatus, TransportType } from '@/transport/types'
+
+export { Icon } from './Icon'
 
 // ── Button ────────────────────────────────────────────────────────────────────
 
@@ -230,10 +235,11 @@ export function Modal({ open, onClose, title, children, maxWidth = '480px' }: Mo
             </h3>
             <button
               onClick={onClose}
-              className="text-xl leading-none hover:opacity-60 transition-opacity"
+              aria-label="Close"
+              className="flex items-center justify-center w-7 h-7 rounded hover:bg-black/5 transition-opacity"
               style={{ color: 'var(--color-muted)' }}
             >
-              ×
+              <Icon icon={X} size="sm" />
             </button>
           </div>
         )}
@@ -258,7 +264,19 @@ export function Empty({ icon = '○', message }: { icon?: string; message: strin
 
 // ── Transport status pill ─────────────────────────────────────────────────────
 
-import type { TransportStatus, TransportType } from '@/transport/types'
+const TRANSPORT_ICON: Record<TransportStatus, typeof Network> = {
+  connected: CircleDot,
+  connecting: CircleDot,
+  disconnected: CircleOff,
+  idle: CircleOff,
+  error: CircleOff,
+}
+
+function transportTypeIcon(type: TransportType): typeof Network {
+  if (type === 'peer') return Network
+  if (type === 'gun') return Radio
+  return CircleOff
+}
 
 export function TransportPill({ status, type }: { status: TransportStatus; type: TransportType }) {
   const color =
@@ -267,6 +285,7 @@ export function TransportPill({ status, type }: { status: TransportStatus; type:
       : status === 'connecting'
         ? 'var(--color-gold)'
         : 'var(--color-muted)'
+
   const label =
     status === 'connected'
       ? type === 'peer'
@@ -275,12 +294,16 @@ export function TransportPill({ status, type }: { status: TransportStatus; type:
       : status === 'connecting'
         ? 'Connecting…'
         : 'Offline'
+
+  // Show transport type icon when connected, generic status icon otherwise
+  const IconComponent = status === 'connected' ? transportTypeIcon(type) : TRANSPORT_ICON[status]
+
   return (
     <span
       className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium mono border"
       style={{ borderColor: color, color }}
     >
-      <span className="w-1.5 h-1.5 rounded-full inline-block" style={{ background: color }} />
+      <Icon icon={IconComponent} size="sm" className="shrink-0" />
       {label}
     </span>
   )

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { QRCodeSVG } from 'qrcode.react'
+import { QrCode, Rocket, Hourglass, CircleDot, Circle } from 'lucide-react'
 import AdminLayout from '@/components/AdminLayout'
-import { Button, Badge, TransportPill } from '@/components/ui'
+import { Button, Badge, TransportPill, Icon } from '@/components/ui'
 import { NavHeader } from '@/components/NavHeader'
 import { RoundBoundary } from '@/components/RoundBoundary'
 import { BuzzerPanel } from '@/components/buzzer/BuzzerPanel'
@@ -41,10 +42,13 @@ function PlayerRow({ player }: { player: Player }) {
       className="flex items-center gap-3 px-4 py-2.5 border-b last:border-b-0"
       style={{ borderColor: 'var(--color-border)' }}
     >
-      <span
-        className="w-2 h-2 rounded-full shrink-0"
-        style={{ background: player.isAway ? 'var(--color-muted)' : 'var(--color-green)' }}
-        title={player.isAway ? 'Away' : 'Online'}
+      <Icon
+        icon={player.isAway ? Circle : CircleDot}
+        size="sm"
+        className="shrink-0"
+        aria-hidden={false}
+        aria-label={player.isAway ? 'Away' : 'Online'}
+        // colour via inline style since CSS vars aren't Tailwind classes
       />
       <span className="flex-1 text-sm">{player.name}</span>
       {player.isAway && (
@@ -120,9 +124,10 @@ function Lobby({
           style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
         >
           <p
-            className="text-xs font-semibold uppercase tracking-wider"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider"
             style={{ color: 'var(--color-muted)' }}
           >
+            <Icon icon={QrCode} size="sm" />
             Scan to join
           </p>
 
@@ -183,7 +188,8 @@ function Lobby({
 
           <div className="flex-1 overflow-y-auto" style={{ maxHeight: 240 }}>
             {players.length === 0 ? (
-              <div className="flex items-center justify-center h-24">
+              <div className="flex flex-col items-center justify-center gap-2 h-24">
+                <Icon icon={Hourglass} size="md" aria-hidden />
                 <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
                   Waiting for players to join…
                 </p>
@@ -264,7 +270,8 @@ function Lobby({
           </label>
 
           <Button variant="primary" size="lg" onClick={onStart} disabled={!canStart || starting}>
-            {starting ? 'Starting…' : 'Start game →'}
+            <Icon icon={Rocket} size="sm" />
+            {starting ? 'Starting…' : 'Start game'}
           </Button>
         </div>
       </div>

--- a/src/pages/admin/Questions.tsx
+++ b/src/pages/admin/Questions.tsx
@@ -1,7 +1,21 @@
 import { useEffect, useState, useRef, useMemo, useCallback } from 'react'
 import Fuse from 'fuse.js'
 import AdminLayout from '@/components/AdminLayout'
-import { Button, Badge, Input, Select, Modal, Textarea, Empty } from '@/components/ui'
+import { Button, Badge, Input, Select, Modal, Textarea, Empty, Icon } from '@/components/ui'
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Download,
+  Upload,
+  ListChecks,
+  ToggleLeft,
+  PencilLine,
+  ChevronUp,
+  ChevronDown,
+  CircleCheck,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 import { db } from '@/db'
 import { exportQuestions, importQuestions, downloadExampleQuestions } from '@/db/snapshot'
 import type { ImportResult } from '@/db/snapshot'
@@ -29,6 +43,12 @@ const TYPE_LABELS: Record<QuestionType, string> = {
   open_ended: 'Open ended',
 }
 
+const TYPE_ICONS: Record<QuestionType, LucideIcon> = {
+  multiple_choice: ListChecks,
+  true_false: ToggleLeft,
+  open_ended: PencilLine,
+}
+
 // ── Tri-state tag filter ──────────────────────────────────────────────────────
 
 export type TagFilterState = 'none' | 'include' | 'exclude'
@@ -39,10 +59,10 @@ const TAG_FILTER_NEXT: Record<TagFilterState, TagFilterState> = {
   exclude: 'none',
 }
 
-const TAG_FILTER_ICON: Record<TagFilterState, string> = {
-  none: '',
-  include: '✓',
-  exclude: '✕',
+const TAG_FILTER_ICON: Record<TagFilterState, LucideIcon | null> = {
+  none: null,
+  include: CircleCheck,
+  exclude: Trash2,
 }
 
 interface TagFilterPillProps {
@@ -73,10 +93,8 @@ function TagFilterPill({ tag, state, onChange }: TagFilterPillProps) {
         textDecoration: isExclude ? 'line-through' : 'none',
       }}
     >
-      {isActive && (
-        <span style={{ fontStyle: 'normal', textDecoration: 'none', display: 'inline-block' }}>
-          {TAG_FILTER_ICON[state]}
-        </span>
+      {isActive && TAG_FILTER_ICON[state] && (
+        <Icon icon={TAG_FILTER_ICON[state]!} size="sm" aria-hidden />
       )}
       {tag.name}
     </button>
@@ -769,16 +787,19 @@ export default function Questions() {
             {selected.size > 0 && (
               <>
                 <Button variant="ghost" size="sm" onClick={() => setRoundModal(true)}>
-                  + Round from {selected.size} selected
+                  <Icon icon={Plus} size="sm" />
+                  Round from {selected.size} selected
                 </Button>
                 <Button
                   variant="secondary"
                   size="sm"
                   onClick={() => exportQuestions([...selected])}
                 >
-                  ↓ Export {selected.size}
+                  <Icon icon={Download} size="sm" />
+                  Export {selected.size}
                 </Button>
                 <Button variant="danger" size="sm" onClick={() => handleDelete([...selected])}>
+                  <Icon icon={Trash2} size="sm" />
                   Delete {selected.size}
                 </Button>
               </>
@@ -792,7 +813,8 @@ export default function Questions() {
                 disabled={importing}
                 onClick={() => importRef.current?.click()}
               >
-                {importing ? 'Importing…' : '↑ Import'}
+                <Icon icon={Upload} size="sm" />
+                {importing ? 'Importing…' : 'Import'}
               </Button>
               <input
                 ref={importRef}
@@ -805,12 +827,14 @@ export default function Questions() {
 
             {selected.size === 0 && (
               <Button variant="secondary" size="sm" onClick={() => exportQuestions()}>
-                ↓ Export all
+                <Icon icon={Download} size="sm" />
+                Export all
               </Button>
             )}
 
             <Button variant="primary" size="sm" onClick={() => setEditing({})}>
-              + New question
+              <Icon icon={Plus} size="sm" />
+              New question
             </Button>
           </div>
 
@@ -884,15 +908,17 @@ export default function Questions() {
                         <div className="flex flex-col gap-0.5 mt-0.5">
                           <button
                             onClick={() => moveInRound(q.id, -1)}
-                            className="text-xs opacity-30 hover:opacity-80 leading-none"
+                            className="opacity-30 hover:opacity-80 flex items-center"
+                            aria-label="Move question up"
                           >
-                            ▲
+                            <Icon icon={ChevronUp} size="sm" />
                           </button>
                           <button
                             onClick={() => moveInRound(q.id, 1)}
-                            className="text-xs opacity-30 hover:opacity-80 leading-none"
+                            className="opacity-30 hover:opacity-80 flex items-center"
+                            aria-label="Move question down"
                           >
-                            ▼
+                            <Icon icon={ChevronDown} size="sm" />
                           </button>
                         </div>
                       )}
@@ -902,7 +928,10 @@ export default function Questions() {
                           <p className="text-sm font-medium leading-snug">{q.title}</p>
                           <div className="flex items-center gap-2 shrink-0">
                             {diff && <Badge color={diff.color + '33'}>{diff.name}</Badge>}
-                            <Badge>{TYPE_LABELS[q.type]}</Badge>
+                            <Badge>
+                              <Icon icon={TYPE_ICONS[q.type]} size="sm" className="mr-1" />
+                              {TYPE_LABELS[q.type]}
+                            </Badge>
                           </div>
                         </div>
                         {q.answer && (
@@ -929,16 +958,24 @@ export default function Questions() {
                       </div>
 
                       <div className="flex gap-1 shrink-0">
-                        <Button variant="ghost" size="sm" onClick={() => setEditing(q)}>
-                          Edit
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => setEditing(q)}
+                          aria-label="Edit question"
+                          title="Edit"
+                        >
+                          <Icon icon={Pencil} size="sm" />
                         </Button>
                         <Button
                           variant="ghost"
                           size="sm"
                           onClick={() => handleDelete([q.id])}
+                          aria-label="Delete question"
+                          title="Delete"
                           style={{ color: 'var(--color-red)' }}
                         >
-                          Del
+                          <Icon icon={Trash2} size="sm" />
                         </Button>
                       </div>
                     </div>

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -4,7 +4,8 @@ import ManageDifficulties from '@/components/settings/ManageDifficulties'
 import { exportDatabase, importDatabase } from '@/db/snapshot'
 import { purgeDatabase, seedDefaults } from '@/db'
 import { useState } from 'react'
-import { Button, Modal, Input } from '@/components/ui'
+import { Button, Modal, Input, Icon } from '@/components/ui'
+import { Download, Trash2 } from 'lucide-react'
 
 export default function Settings() {
   const [importing, setImporting] = useState(false)
@@ -93,6 +94,7 @@ export default function Settings() {
 
           <div className="flex flex-wrap gap-3">
             <Button variant="secondary" onClick={exportDatabase}>
+              <Icon icon={Download} size="sm" />
               Export JSON
             </Button>
 
@@ -143,6 +145,7 @@ export default function Settings() {
               </p>
             </div>
             <Button variant="danger" size="sm" onClick={() => setPurgeOpen(true)}>
+              <Icon icon={Trash2} size="sm" />
               Purge
             </Button>
           </div>

--- a/src/test/Icon.test.tsx
+++ b/src/test/Icon.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Settings } from 'lucide-react'
+import { Icon } from '@/components/ui/Icon'
+
+describe('Icon', () => {
+  it('renders aria-hidden by default', () => {
+    const { container } = render(<Icon icon={Settings} />)
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg!.getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('renders at 16px for size sm (default)', () => {
+    const { container } = render(<Icon icon={Settings} size="sm" />)
+    const svg = container.querySelector('svg')
+    expect(svg!.getAttribute('width')).toBe('16')
+    expect(svg!.getAttribute('height')).toBe('16')
+  })
+
+  it('renders at 20px for size md', () => {
+    const { container } = render(<Icon icon={Settings} size="md" />)
+    const svg = container.querySelector('svg')
+    expect(svg!.getAttribute('width')).toBe('20')
+    expect(svg!.getAttribute('height')).toBe('20')
+  })
+
+  it('passes aria-label when aria-hidden is false', () => {
+    render(<Icon icon={Settings} aria-hidden={false} aria-label="settings icon" />)
+    expect(screen.getByLabelText('settings icon')).toBeTruthy()
+  })
+
+  it('forwards className', () => {
+    const { container } = render(<Icon icon={Settings} className="text-red-500" />)
+    const svg = container.querySelector('svg')
+    expect(svg!.classList.contains('text-red-500')).toBe(true)
+  })
+})

--- a/src/test/ui.test.tsx
+++ b/src/test/ui.test.tsx
@@ -194,14 +194,14 @@ describe('Modal', () => {
     expect(screen.getByText('Confirm')).toBeInTheDocument()
   })
 
-  it('calls onClose when the × button is clicked', () => {
+  it('calls onClose when the close button is clicked', () => {
     const onClose = vi.fn()
     render(
       <Modal open title="Test" onClose={onClose}>
         body
       </Modal>
     )
-    fireEvent.click(screen.getByText('×'))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
     expect(onClose).toHaveBeenCalledOnce()
   })
 


### PR DESCRIPTION
## Checklist

- [x] PR title follows conventional commits — `type(scope): description`
- [x] Tests added or updated
- [x] `npm run test` passes locally
- [x] `npm run build` passes locally
- [x] `npm run lint` passes locally
- [x] No `console.log` left in production paths

Closes #89
Closes #90 
Closes #91 
Closes #92 
Closes #93 
Closes #94 
Closes #95 
Closes #96
