### PR TITLE
feat(ci): skip tests when no code files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-node@v6
         with:
@@ -30,8 +32,21 @@ jobs:
       - name: Lint PR title
         run: echo "${{ github.event.pull_request.title }}" | npx --yes commitlint
 
+  detect:
+      runs-on: ubuntu-latest
+      outputs:
+        code: ${{ steps.changes.outputs.code }}
+      steps:
+        - uses: actions/checkout@v6
+
+        - name: Detect code changes
+          id: changes
+          run: bash scripts/detect-code-changes.sh "${{ github.event.pull_request.base.sha }}"
+
   ci:
     runs-on: ubuntu-latest
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -54,7 +69,6 @@ jobs:
         run: npm run test:coverage
 
       - name: Coverage summary
-        if: always()
         run: bash scripts/coverage-summary.sh
 
       - name: Build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,8 @@
 npx lint-staged
-npm run typecheck
-npm run test
+
+if bash scripts/detect-code-changes.sh --staged | grep -q '^code=true$'; then
+  npm run typecheck
+  npm run test
+else
+  echo "No code files staged -- skipping typecheck and tests."
+fi

--- a/scripts/detect-code-changes.sh
+++ b/scripts/detect-code-changes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# detect-code-changes.sh — check if any code files changed
+#
+# Usage:
+#   detect-code-changes.sh <base-sha>   # diff HEAD vs base (CI)
+#   detect-code-changes.sh --staged     # diff staged files (pre-commit)
+set -euo pipefail
+
+CODE_PATTERNS="^src/|^\.github/|vite\.config\.|tsconfig|package\.json|\.config\.ts"
+
+if [[ "${1:-}" == "--staged" ]]; then
+  CHANGED=$(git diff --cached --name-only)
+else
+  BASE="${1:?'Usage: detect-code-changes.sh <base-sha>'}"
+  git fetch origin "$BASE" --depth=1
+  CHANGED=$(git diff --name-only "$BASE" HEAD)
+fi
+
+echo "changed files:"
+echo "$CHANGED"
+
+if echo "$CHANGED" | grep --color -qE "$CODE_PATTERNS"; then
+  RESULT="true"
+  echo "=> code changes detected"
+else
+  RESULT="false"
+  echo "=> no code changes"
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "code=$RESULT" >> "$GITHUB_OUTPUT"
+else
+  echo "code=$RESULT"
+fi


### PR DESCRIPTION
Add a detect-code-changes step that diffs PR base..head and checks whether any file matching src/, scripts/, vite.config.*, tsconfig, package.json, or *.config.ts changed. Typecheck, lint, test, coverage, and build steps are all conditional on that output.

Use detect-code-changes.sh --staged to gate typecheck and test runs on whether any source files are in the index. lint-staged remains unconditional as it is already file-scoped.