### PR TITLE
feat(routing): open notes directly via /admin/notes/:id

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const Games = lazy(() => import('@/pages/admin/Games'))
 const GameMaster = lazy(() => import('@/pages/admin/GameMaster'))
 const Layouts = lazy(() => import('@/pages/admin/Layouts'))
 const Notes = lazy(() => import('@/pages/admin/Notes'))
+const NoteDetail = lazy(() => import('@/pages/admin/NoteDetail'))
 const Settings = lazy(() => import('@/pages/admin/Settings'))
 
 // Pages — Player (lazy-loaded per route)
@@ -37,6 +38,7 @@ export default function App() {
           <Route path="/admin/game/:id" element={<GameMaster />} />
           <Route path="/admin/layouts/:gameId" element={<Layouts />} />
           <Route path="/admin/notes" element={<Notes />} />
+          <Route path="/admin/notes/:id" element={<NoteDetail />} />
           <Route path="/admin/settings" element={<Settings />} />
           <Route path="/join" element={<Join />} />
           <Route path="/join/:roomId" element={<Join />} />

--- a/src/pages/admin/NoteDetail.tsx
+++ b/src/pages/admin/NoteDetail.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { db } from '@/db'
+import type { Note } from '@/db'
+
+function formatDate(ts: number) {
+  return new Date(ts).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+export default function NoteDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [note, setNote] = useState<Note | null | undefined>(undefined) // undefined = loading
+
+  useEffect(() => {
+    if (!id) return
+    db.notes.get(id).then(n => setNote(n ?? null))
+  }, [id])
+
+  if (note === undefined) return null // still loading — no flash
+
+  if (note === null) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center h-screen gap-4"
+        style={{ background: 'var(--color-cream)', color: 'var(--color-ink)' }}
+      >
+        <p
+          className="text-6xl font-black"
+          style={{ fontFamily: 'Playfair Display, serif', color: 'var(--color-muted)' }}
+        >
+          404
+        </p>
+        <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
+          Note not found.
+        </p>
+        <Link
+          to="/admin/notes"
+          className="text-sm underline"
+          style={{ color: 'var(--color-gold)' }}
+        >
+          Back to notes
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: 'var(--color-cream)', color: 'var(--color-ink)' }}
+    >
+      <div className="max-w-2xl mx-auto px-6 py-12">
+        <div className="mb-8">
+          <Link
+            to="/admin/notes"
+            className="text-xs mb-6 inline-block"
+            style={{ color: 'var(--color-muted)' }}
+          >
+            ← Notes
+          </Link>
+          <h1
+            className="text-3xl font-bold mt-2"
+            style={{ fontFamily: 'Playfair Display, serif' }}
+          >
+            {note.name}
+          </h1>
+          <p className="text-xs mt-1" style={{ color: 'var(--color-muted)' }}>
+            Updated {formatDate(note.updatedAt)}
+          </p>
+        </div>
+
+        {note.content.trim() ? (
+          <div className="note-prose">
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{note.content}</ReactMarkdown>
+          </div>
+        ) : (
+          <p style={{ color: 'var(--color-muted)', fontStyle: 'italic' }}>This note is empty.</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/Notes.tsx
+++ b/src/pages/admin/Notes.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import AdminLayout from '@/components/AdminLayout'
@@ -320,32 +321,44 @@ export default function Notes() {
               </div>
             ) : (
               filtered.map(note => (
-                <button
+                <div
                   key={note.id}
-                  onClick={() => setSelected(note.id)}
-                  className="w-full text-left px-4 py-3 border-b transition-all"
+                  className="relative border-b group"
                   style={{
                     borderColor: 'var(--color-border)',
                     background: selected === note.id ? 'var(--color-gold-light)' : 'transparent',
                   }}
                 >
-                  <p
-                    className="text-sm truncate"
-                    style={{ fontWeight: selected === note.id ? 600 : 400 }}
+                  <button
+                    onClick={() => setSelected(note.id)}
+                    className="w-full text-left px-4 py-3 pr-8 transition-all"
                   >
-                    {note.name}
-                  </p>
-                  <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--color-muted)' }}>
-                    {formatDate(note.updatedAt)}
-                    {note.content.trim()
-                      ? ' · ' +
-                        note.content
-                          .trim()
-                          .slice(0, 40)
-                          .replace(/[#*`_]/g, '')
-                      : ''}
-                  </p>
-                </button>
+                    <p
+                      className="text-sm truncate"
+                      style={{ fontWeight: selected === note.id ? 600 : 400 }}
+                    >
+                      {note.name}
+                    </p>
+                    <p className="text-xs mt-0.5 truncate" style={{ color: 'var(--color-muted)' }}>
+                      {formatDate(note.updatedAt)}
+                      {note.content.trim()
+                        ? ' · ' +
+                          note.content
+                            .trim()
+                            .slice(0, 40)
+                            .replace(/[#*`_]/g, '')
+                        : ''}
+                    </p>
+                  </button>
+                  <Link
+                    to={`/admin/notes/${note.id}`}
+                    title="Open note page"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-60 hover:!opacity-100 transition-opacity text-xs leading-none"
+                    style={{ color: 'var(--color-muted)' }}
+                  >
+                    ↗
+                  </Link>
+                </div>
               ))
             )}
           </div>

--- a/src/test/note-detail.test.tsx
+++ b/src/test/note-detail.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-pool vmForks
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { act } from 'react'
+import { db } from '@/db'
+import type { Note } from '@/db'
+import NoteDetail from '@/pages/admin/NoteDetail'
+
+function makeNote(overrides: Partial<Note> = {}): Note {
+  const ts = Date.now()
+  return {
+    id: crypto.randomUUID(),
+    name: 'Test Note',
+    content: '# Hello\n\nWorld',
+    createdAt: ts,
+    updatedAt: ts,
+    ...overrides,
+  }
+}
+
+function renderAt(id: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/notes/${id}`]}>
+      <Routes>
+        <Route path="/admin/notes/:id" element={<NoteDetail />} />
+        <Route path="/admin/notes" element={<div>Notes list</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(async () => {
+  await db.notes.clear()
+})
+
+describe('NoteDetail', () => {
+  it('renders the note title and content when found', async () => {
+    const note = makeNote({ name: 'My Round Intro', content: '## Welcome\n\nGood luck!' })
+    await act(async () => {
+      await db.notes.add(note)
+    })
+
+    renderAt(note.id)
+
+    await waitFor(() => expect(screen.getByText('My Round Intro')).toBeInTheDocument())
+    expect(screen.getByRole('heading', { name: 'Welcome' })).toBeInTheDocument()
+  })
+
+  it('shows 404 and back link when note id does not exist', async () => {
+    renderAt('nonexistent-id')
+
+    await waitFor(() => expect(screen.getByText('404')).toBeInTheDocument())
+    expect(screen.getByText('Note not found.')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Back to notes' })).toBeInTheDocument()
+  })
+
+  it('shows empty state message when note content is blank', async () => {
+    const note = makeNote({ name: 'Empty Note', content: '   ' })
+    await act(async () => {
+      await db.notes.add(note)
+    })
+
+    renderAt(note.id)
+
+    await waitFor(() => expect(screen.getByText('Empty Note')).toBeInTheDocument())
+    expect(screen.getByText('This note is empty.')).toBeInTheDocument()
+  })
+
+  it('renders a back link pointing to /admin/notes', async () => {
+    const note = makeNote()
+    await act(async () => {
+      await db.notes.add(note)
+    })
+
+    renderAt(note.id)
+
+    await waitFor(() => screen.getByText(note.name))
+    const link = screen.getByRole('link', { name: '← Notes' })
+    expect(link).toHaveAttribute('href', '/admin/notes')
+  })
+})

--- a/src/test/routing.test.tsx
+++ b/src/test/routing.test.tsx
@@ -30,6 +30,7 @@ function TestRoutes() {
       <Route path="/admin/game/:id" element={<div>GameMaster</div>} />
       <Route path="/admin/layouts/:gameId" element={<div>Layouts</div>} />
       <Route path="/admin/notes" element={<div>Notes</div>} />
+      <Route path="/admin/notes/:id" element={<div>NoteDetail</div>} />
       <Route path="/admin/settings" element={<div>Settings</div>} />
       <Route path="/join" element={<div>Join</div>} />
       <Route path="/join/:roomId" element={<div>Join</div>} />
@@ -81,6 +82,11 @@ describe('App routing', () => {
   it('renders Notes at /admin/notes', () => {
     renderAt('/admin/notes')
     expect(screen.getByText('Notes')).toBeInTheDocument()
+  })
+
+  it('renders NoteDetail at /admin/notes/:id', () => {
+    renderAt('/admin/notes/some-note-id')
+    expect(screen.getByText('NoteDetail')).toBeInTheDocument()
   })
 
   it('renders Settings at /admin/settings', () => {


### PR DESCRIPTION
Add a clean full-page note view accessible at /admin/notes/:id.

- NoteDetail page: fetches note by id param, renders title + markdown content using note-prose styles; shows a 404 state with back link when the id does not match any stored note
- App.tsx: register /admin/notes/:id route (lazy-loaded)
- Notes.tsx: sidebar items gain a hover-revealed link icon (arrow) that navigates to the note's direct URL without leaving the notes list
- Tests: note-detail.test.tsx covers found / not-found / empty-content / back-link; routing.test.tsx extended with /admin/notes/:id case

Closes #121 