### PR TITLE
fix(github): use pull_request_target for dependabot automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,7 +1,7 @@
 name: Auto-merge Dependabot
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -18,7 +18,6 @@ env:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    # Only run for Dependabot PRs where CI has passed
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
The pull_request trigger runs Dependabot PRs with a read-only token (GitHub's post-2021 fork security model), causing `gh pr merge` to silently fail or be skipped.

Switching to pull_request_target runs the workflow in the base branch context with write permissions. The github.actor == 'dependabot[bot]' guard makes this safe — Dependabot never modifies base-branch code.

Fixes #142 