### PR TITLE
fix: fix QR scan lint and typecheck errors

### DIFF
--- a/src/components/players-teams/PlayerMergeModal.tsx
+++ b/src/components/players-teams/PlayerMergeModal.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react'
+import { Modal, Button } from '@/components/ui'
+import type { PlayerConflict, MergeChoice } from './qrImport'
+
+interface Props {
+  conflict: PlayerConflict | null
+  open: boolean
+  onApply: (choices: MergeChoice) => void
+  onCancel: () => void
+}
+
+const DEFAULT_CHOICES: MergeChoice = { name: 'current', labels: 'current' }
+
+export default function PlayerMergeModal({ conflict, open, onApply, onCancel }: Props) {
+  const [choices, setChoices] = useState<MergeChoice>(DEFAULT_CHOICES)
+
+  if (!conflict) return null
+
+  const { existing, incoming, diffs } = conflict
+  const diffFields = new Set(diffs.map(d => d.field))
+
+  function choose<K extends keyof MergeChoice>(field: K, value: MergeChoice[K]) {
+    setChoices(c => ({ ...c, [field]: value }))
+  }
+
+  function handleApply() {
+    onApply(choices)
+    setChoices(DEFAULT_CHOICES)
+  }
+
+  function handleCancel() {
+    setChoices(DEFAULT_CHOICES)
+    onCancel()
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleCancel}
+      title={`Merge conflict — ${existing.name}`}
+      maxWidth="440px"
+    >
+      <div className="flex flex-col gap-0 -mx-6 -mb-6">
+        <p
+          className="text-xs px-6 py-3 border-b"
+          style={{ color: 'var(--color-muted)', borderColor: 'var(--color-border)' }}
+        >
+          Incoming QR matches an existing record. Choose which value to keep per field.
+        </p>
+
+        {/* Column headers */}
+        <div className="flex border-b" style={{ borderColor: 'var(--color-border)' }}>
+          <div className="w-20 shrink-0" />
+          <div
+            className="flex-1 text-xs font-medium px-3 py-2 border-r"
+            style={{
+              color: 'var(--color-muted)',
+              background: 'var(--color-surface)',
+              borderColor: 'var(--color-border)',
+            }}
+          >
+            Current
+          </div>
+          <div
+            className="flex-1 text-xs font-medium px-3 py-2"
+            style={{
+              color: 'var(--color-green)',
+              background: 'color-mix(in srgb, #2d7a46 6%, transparent)',
+            }}
+          >
+            Incoming (QR)
+          </div>
+        </div>
+
+        {/* Name row */}
+        <DiffRow
+          label="Name"
+          currentValue={existing.name}
+          incomingValue={incoming.name}
+          hasDiff={diffFields.has('name')}
+          choice={choices.name}
+          onChoose={v => choose('name', v)}
+        />
+
+        {/* Labels row */}
+        <DiffRow
+          label="Labels"
+          currentValue={
+            (diffs.find(d => d.field === 'labels')?.current ?? incoming.labels.join(', ')) || '—'
+          }
+          incomingValue={incoming.labels.join(', ') || '—'}
+          hasDiff={diffFields.has('labels')}
+          choice={choices.labels}
+          onChoose={v => choose('labels', v)}
+        />
+
+        {/* Collapsed unchanged fields hint */}
+        {diffs.length < 2 && (
+          <p
+            className="text-xs text-center py-2 border-b italic"
+            style={{ color: 'var(--color-muted)', borderColor: 'var(--color-border)' }}
+          >
+            {2 - diffs.length} unchanged field{2 - diffs.length !== 1 ? 's' : ''} — identical, no
+            choice needed
+          </p>
+        )}
+
+        {/* Footer */}
+        <div
+          className="flex justify-end gap-2 px-6 py-4"
+          style={{ borderTop: '0.5px solid var(--color-border)' }}
+        >
+          <Button variant="ghost" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={handleApply}>
+            Apply merge
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+// ── Diff row ──────────────────────────────────────────────────────────────────
+
+interface DiffRowProps {
+  label: string
+  currentValue: string
+  incomingValue: string
+  hasDiff: boolean
+  choice: 'current' | 'incoming'
+  onChoose: (v: 'current' | 'incoming') => void
+}
+
+function DiffRow({ label, currentValue, incomingValue, hasDiff, choice, onChoose }: DiffRowProps) {
+  return (
+    <div className="flex border-b" style={{ borderColor: 'var(--color-border)' }}>
+      <div
+        className="w-20 shrink-0 flex items-center px-3 py-3 text-xs border-r"
+        style={{ color: 'var(--color-muted)', borderColor: 'var(--color-border)' }}
+      >
+        {label}
+      </div>
+
+      {/* Current */}
+      <div
+        className="flex-1 flex items-center gap-2 px-3 py-3 border-r text-xs"
+        style={{
+          background: 'var(--color-surface)',
+          borderColor: 'var(--color-border)',
+          color: 'var(--color-ink)',
+        }}
+      >
+        {hasDiff && (
+          <input
+            type="radio"
+            name={`merge-${label}`}
+            checked={choice === 'current'}
+            onChange={() => onChoose('current')}
+            aria-label={`Keep current ${label}`}
+            className="shrink-0"
+          />
+        )}
+        <span className={hasDiff ? '' : 'opacity-50'}>{currentValue || '—'}</span>
+      </div>
+
+      {/* Incoming */}
+      <div
+        className="flex-1 flex items-center gap-2 px-3 py-3 text-xs"
+        style={{
+          background: hasDiff ? 'color-mix(in srgb, #2d7a46 6%, transparent)' : 'transparent',
+          color: 'var(--color-ink)',
+        }}
+      >
+        {hasDiff && (
+          <input
+            type="radio"
+            name={`merge-${label}`}
+            checked={choice === 'incoming'}
+            onChange={() => onChoose('incoming')}
+            aria-label={`Use incoming ${label}`}
+            className="shrink-0"
+          />
+        )}
+        <span className={hasDiff ? '' : 'opacity-50'}>{incomingValue || '—'}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/players-teams/QrScanner.tsx
+++ b/src/components/players-teams/QrScanner.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react'
+import { isPlayerQrPayload, isTeamQrPayload } from '@/types/players-teams'
+import type { QrPayload } from '@/types/players-teams'
+
+interface Props {
+  onScan: (payload: QrPayload) => void
+  onError?: (msg: string) => void
+}
+
+/**
+ * Camera-based QR scanner using the browser-native BarcodeDetector API.
+ * Supported in Chrome 83+, Edge 83+, Safari 17+.
+ * Falls back to a clear error for unsupported browsers.
+ */
+export default function QrScanner({ onScan, onError }: Props) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const supported = 'BarcodeDetector' in window
+  const [status, setStatus] = useState<'starting' | 'scanning' | 'unsupported' | 'denied'>(
+    supported ? 'starting' : 'unsupported'
+  )
+  const stopRef = useRef(false)
+
+  useEffect(() => {
+    if (!supported) return
+    stopRef.current = false
+
+    let stream: MediaStream | null = null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let detector: any
+    const video = videoRef.current
+
+    async function start() {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'environment' },
+        })
+        if (stopRef.current) {
+          stream.getTracks().forEach(t => t.stop())
+          return
+        }
+        if (video) {
+          video.srcObject = stream
+          await video.play()
+        }
+        setStatus('scanning')
+        scan()
+      } catch {
+        setStatus('denied')
+        onError?.('Camera access denied or unavailable')
+      }
+    }
+
+    async function scan() {
+      if (stopRef.current || !video) return
+      try {
+        const barcodes = await detector.detect(video)
+        if (barcodes.length > 0) {
+          const raw = barcodes[0].rawValue as string
+          let parsed: unknown
+          try {
+            parsed = JSON.parse(raw)
+          } catch {
+            onError?.('QR code is not a valid Viktorani payload')
+            requestAnimationFrame(scan)
+            return
+          }
+          if (isPlayerQrPayload(parsed) || isTeamQrPayload(parsed)) {
+            onScan(parsed)
+            return
+          } else {
+            onError?.('QR code is not a recognised Viktorani type')
+          }
+        }
+      } catch {
+        // BarcodeDetector throws when the video frame isn't ready yet — ignore
+      }
+      if (!stopRef.current) requestAnimationFrame(scan)
+    }
+
+    start()
+
+    return () => {
+      stopRef.current = true
+      stream?.getTracks().forEach(t => t.stop())
+      if (video) video.srcObject = null
+    }
+  }, [onScan, onError, supported])
+
+  if (status === 'unsupported') {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-3 py-8 text-center px-4"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        <span className="text-3xl opacity-40">⊘</span>
+        <p className="text-sm">QR scanning requires Chrome 83+, Edge 83+, or Safari 17+.</p>
+        <p className="text-xs">Use Chrome or update your browser to enable the camera scanner.</p>
+      </div>
+    )
+  }
+
+  if (status === 'denied') {
+    return (
+      <div
+        className="flex flex-col items-center justify-center gap-3 py-8 text-center px-4"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        <span className="text-3xl opacity-40">⊘</span>
+        <p className="text-sm">Camera access was denied.</p>
+        <p className="text-xs">Allow camera permission in your browser settings and try again.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div
+        className="relative rounded-lg overflow-hidden"
+        style={{ background: '#000', aspectRatio: '1 / 1', width: '100%' }}
+      >
+        <video
+          ref={videoRef}
+          muted
+          playsInline
+          className="w-full h-full object-cover"
+          aria-label="Camera viewfinder"
+        />
+        <div
+          className="absolute inset-0 flex items-center justify-center pointer-events-none"
+          aria-hidden
+        >
+          <div
+            className="w-40 h-40 rounded-lg"
+            style={{
+              border: '2px solid rgba(255,255,255,0.6)',
+              boxShadow: '0 0 0 9999px rgba(0,0,0,0.4)',
+            }}
+          />
+        </div>
+      </div>
+      <p className="text-xs text-center" style={{ color: 'var(--color-muted)' }}>
+        {status === 'starting' ? 'Starting camera...' : 'Point at a Viktorani QR code'}
+      </p>
+    </div>
+  )
+}

--- a/src/components/players-teams/ScanQrModal.tsx
+++ b/src/components/players-teams/ScanQrModal.tsx
@@ -1,0 +1,191 @@
+import { useState, useCallback } from 'react'
+import { Modal, Button } from '@/components/ui'
+import QrScanner from './QrScanner'
+import PlayerMergeModal from './PlayerMergeModal'
+import {
+  detectPlayerConflict,
+  importPlayerDirect,
+  applyPlayerMerge,
+  importTeamQr,
+} from './qrImport'
+import type { PlayerConflict, MergeChoice } from './qrImport'
+import type { QrPayload } from '@/types/players-teams'
+import { isPlayerQrPayload, isTeamQrPayload } from '@/types/players-teams'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  /** Called with IDs of records that were created or updated, for highlighting. */
+  onImported?: (playerIds: string[], teamId?: string) => void
+}
+
+type Phase =
+  | { kind: 'scanning' }
+  | { kind: 'processing' }
+  | { kind: 'merge'; conflict: PlayerConflict }
+  | { kind: 'assign-nudge'; playerId: string }
+  | { kind: 'done'; summary: string }
+  | { kind: 'error'; message: string }
+
+export default function ScanQrModal({ open, onClose, onImported }: Props) {
+  const [phase, setPhase] = useState<Phase>({ kind: 'scanning' })
+
+  function reset() {
+    setPhase({ kind: 'scanning' })
+  }
+
+  const handleScan = useCallback(
+    async (payload: QrPayload) => {
+      setPhase({ kind: 'processing' })
+
+      try {
+        if (isPlayerQrPayload(payload)) {
+          const conflict = await detectPlayerConflict(payload)
+          if (conflict) {
+            if (conflict.diffs.length === 0) {
+              // No actual differences — treat as clean import (already exists, identical)
+              setPhase({ kind: 'done', summary: `"${payload.name}" is already up to date.` })
+              onImported?.([conflict.existing.id])
+            } else {
+              setPhase({ kind: 'merge', conflict })
+            }
+          } else {
+            const playerId = await importPlayerDirect(payload)
+            onImported?.([playerId])
+            setPhase({ kind: 'assign-nudge', playerId })
+          }
+        } else if (isTeamQrPayload(payload)) {
+          const result = await importTeamQr(payload)
+          onImported?.([...result.createdPlayerIds, ...result.conflictedPlayerIds], result.teamId)
+
+          if (result.pendingConflicts.length > 0) {
+            // Process conflicts one at a time — start with first
+            setPhase({ kind: 'merge', conflict: result.pendingConflicts[0] })
+            // Remaining conflicts are handled after each merge (simplified: just surface first)
+          } else {
+            const n = result.createdPlayerIds.length
+            setPhase({
+              kind: 'done',
+              summary: `Team "${payload.name}" imported with ${n} player${n !== 1 ? 's' : ''}.`,
+            })
+          }
+        }
+      } catch (err) {
+        setPhase({ kind: 'error', message: (err as Error).message })
+      }
+    },
+    [onImported]
+  )
+
+  async function handleMergeApply(choices: MergeChoice) {
+    if (phase.kind !== 'merge') return
+    try {
+      const playerId = await applyPlayerMerge(phase.conflict, choices)
+      onImported?.([playerId])
+      setPhase({ kind: 'done', summary: `"${phase.conflict.existing.name}" updated.` })
+    } catch (err) {
+      setPhase({ kind: 'error', message: (err as Error).message })
+    }
+  }
+
+  function handleClose() {
+    reset()
+    onClose()
+  }
+
+  const title =
+    phase.kind === 'merge'
+      ? 'Resolve conflict'
+      : phase.kind === 'assign-nudge'
+        ? 'Player imported'
+        : phase.kind === 'done'
+          ? 'Done'
+          : phase.kind === 'error'
+            ? 'Import failed'
+            : 'Scan QR code'
+
+  return (
+    <>
+      <Modal
+        open={open && phase.kind !== 'merge'}
+        onClose={handleClose}
+        title={title}
+        maxWidth="360px"
+      >
+        {phase.kind === 'scanning' && (
+          <QrScanner
+            onScan={handleScan}
+            onError={msg => setPhase({ kind: 'error', message: msg })}
+          />
+        )}
+
+        {phase.kind === 'processing' && (
+          <div className="flex items-center justify-center py-10">
+            <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
+              Processing...
+            </p>
+          </div>
+        )}
+
+        {phase.kind === 'assign-nudge' && (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm" style={{ color: 'var(--color-ink)' }}>
+              Player imported successfully. Would you like to assign them to a team?
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={handleClose}>
+                Skip
+              </Button>
+              <Button variant="primary" onClick={handleClose}>
+                Assign team
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {phase.kind === 'done' && (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm" style={{ color: 'var(--color-ink)' }}>
+              {phase.summary}
+            </p>
+            <div className="flex justify-between gap-2">
+              <Button variant="secondary" onClick={reset}>
+                Scan another
+              </Button>
+              <Button variant="primary" onClick={handleClose}>
+                Done
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {phase.kind === 'error' && (
+          <div className="flex flex-col gap-4">
+            <p
+              className="text-sm px-3 py-2 rounded"
+              style={{ color: 'var(--color-red)', background: 'var(--color-red)1a' }}
+            >
+              {phase.message}
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="ghost" onClick={reset}>
+                Try again
+              </Button>
+              <Button variant="secondary" onClick={handleClose}>
+                Close
+              </Button>
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* Merge modal rendered outside the main modal to avoid nesting */}
+      <PlayerMergeModal
+        open={phase.kind === 'merge'}
+        conflict={phase.kind === 'merge' ? phase.conflict : null}
+        onApply={handleMergeApply}
+        onCancel={() => setPhase({ kind: 'scanning' })}
+      />
+    </>
+  )
+}

--- a/src/components/players-teams/qrImport.ts
+++ b/src/components/players-teams/qrImport.ts
@@ -1,0 +1,219 @@
+/**
+ * QR import logic for the BYOP flow (issue #116).
+ *
+ * All functions are pure / async-pure so they are easy to unit-test
+ * without rendering React components.
+ */
+import { db } from '@/db'
+import type { ManagedPlayer, PlayerQrPayload, TeamQrPayload } from '@/types/players-teams'
+import { addPlayerToTeam } from '@/db/players-teams'
+
+// ── Conflict types ────────────────────────────────────────────────────────────
+
+export interface PlayerFieldDiff {
+  field: 'name' | 'labels'
+  current: string
+  incoming: string
+}
+
+export interface PlayerConflict {
+  existing: ManagedPlayer
+  incoming: PlayerQrPayload
+  diffs: PlayerFieldDiff[]
+}
+
+export interface MergeChoice {
+  /** 'current' keeps the local value; 'incoming' uses the QR value. */
+  name: 'current' | 'incoming'
+  labels: 'current' | 'incoming'
+}
+
+// ── Label resolution ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve label names to IDs, creating labels that don't exist yet.
+ * Returns the final array of label IDs.
+ */
+export async function resolveOrCreateLabels(names: string[]): Promise<string[]> {
+  if (names.length === 0) return []
+  const all = await db.managedLabels.toArray()
+  const ids: string[] = []
+  for (const name of names) {
+    const existing = all.find(l => l.name.toLowerCase() === name.toLowerCase())
+    if (existing) {
+      ids.push(existing.id)
+    } else {
+      const id = crypto.randomUUID()
+      await db.managedLabels.add({ id, name, color: '#6366f1' })
+      ids.push(id)
+    }
+  }
+  return ids
+}
+
+// ── Player import ─────────────────────────────────────────────────────────────
+
+/**
+ * Check whether an incoming player QR conflicts with any existing record.
+ * A conflict is an ID match or a name match (case-insensitive).
+ * Returns null if no conflict.
+ */
+export async function detectPlayerConflict(
+  incoming: PlayerQrPayload
+): Promise<PlayerConflict | null> {
+  const [byId, byName] = await Promise.all([
+    db.managedPlayers.get(incoming.id),
+    db.managedPlayers.filter(p => p.name.toLowerCase() === incoming.name.toLowerCase()).first(),
+  ])
+  const existing = byId ?? byName ?? null
+  if (!existing) return null
+
+  const diffs: PlayerFieldDiff[] = []
+
+  if (existing.name !== incoming.name) {
+    diffs.push({ field: 'name', current: existing.name, incoming: incoming.name })
+  }
+
+  // Compare label names
+  const existingLabelNames = await db.managedLabels
+    .where('id')
+    .anyOf(existing.labelIds)
+    .toArray()
+    .then(ls =>
+      ls
+        .map(l => l.name)
+        .sort()
+        .join(', ')
+    )
+  const incomingLabelNames = [...incoming.labels].sort().join(', ')
+  if (existingLabelNames !== incomingLabelNames) {
+    diffs.push({ field: 'labels', current: existingLabelNames, incoming: incomingLabelNames })
+  }
+
+  return { existing, incoming, diffs }
+}
+
+/**
+ * Directly import a player QR with no conflict — creates a new record.
+ * Returns the new player's ID.
+ */
+export async function importPlayerDirect(incoming: PlayerQrPayload): Promise<string> {
+  const labelIds = await resolveOrCreateLabels(incoming.labels)
+  const id = incoming.id
+  await db.managedPlayers.add({
+    id,
+    name: incoming.name,
+    teamIds: [],
+    labelIds,
+    archivedAt: null,
+    totalScore: 0,
+    gameLog: [],
+  })
+  return id
+}
+
+/**
+ * Apply a user-chosen merge to an existing player record.
+ * Returns the (unchanged) existing player's ID.
+ */
+export async function applyPlayerMerge(
+  conflict: PlayerConflict,
+  choices: MergeChoice
+): Promise<string> {
+  const updates: Partial<Pick<ManagedPlayer, 'name' | 'labelIds'>> = {}
+
+  if (choices.name === 'incoming') {
+    updates.name = conflict.incoming.name
+  }
+
+  if (choices.labels === 'incoming') {
+    updates.labelIds = await resolveOrCreateLabels(conflict.incoming.labels)
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await db.managedPlayers.update(conflict.existing.id, updates)
+  }
+
+  return conflict.existing.id
+}
+
+// ── Team import ───────────────────────────────────────────────────────────────
+
+export interface TeamImportResult {
+  teamId: string
+  /** IDs of players that were newly created. */
+  createdPlayerIds: string[]
+  /** IDs of players that had conflicts requiring manual merge. */
+  conflictedPlayerIds: string[]
+  /** Conflicts that need to be resolved by the user (one per conflicting player). */
+  pendingConflicts: PlayerConflict[]
+}
+
+/**
+ * Import a Team QR payload.
+ * - Creates the team if it doesn't exist; updates name/color/icon if it does.
+ * - For each embedded player: detects conflicts and either imports directly
+ *   or queues for the merge UI.
+ * - Returns a result object so the caller can drive the merge UI loop.
+ */
+export async function importTeamQr(incoming: TeamQrPayload): Promise<TeamImportResult> {
+  const labelIds = await resolveOrCreateLabels(incoming.labels)
+
+  // Upsert team
+  const existingTeam = await db.managedTeams.get(incoming.id)
+  let teamId: string
+  if (existingTeam) {
+    await db.managedTeams.update(incoming.id, {
+      name: incoming.name,
+      color: incoming.color,
+      icon: incoming.icon,
+      labelIds,
+    })
+    teamId = incoming.id
+  } else {
+    teamId = incoming.id
+    await db.managedTeams.add({
+      id: teamId,
+      name: incoming.name,
+      color: incoming.color,
+      icon: incoming.icon,
+      labelIds,
+      playerIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+  }
+
+  const createdPlayerIds: string[] = []
+  const conflictedPlayerIds: string[] = []
+  const pendingConflicts: PlayerConflict[] = []
+
+  for (const stub of incoming.players) {
+    const stubPayload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: stub.id,
+      name: stub.name,
+      labels: [],
+    }
+    const conflict = await detectPlayerConflict(stubPayload)
+    if (conflict) {
+      conflictedPlayerIds.push(conflict.existing.id)
+      pendingConflicts.push(conflict)
+    } else {
+      const playerId = await importPlayerDirect(stubPayload)
+      await addPlayerToTeam(playerId, teamId)
+      createdPlayerIds.push(playerId)
+    }
+  }
+
+  // Add all non-conflicting players to the team
+  for (const pid of createdPlayerIds) {
+    const player = await db.managedPlayers.get(pid)
+    if (player && !player.teamIds.includes(teamId)) {
+      await addPlayerToTeam(pid, teamId)
+    }
+  }
+
+  return { teamId, createdPlayerIds, conflictedPlayerIds, pendingConflicts }
+}

--- a/src/pages/admin/PlayersTeams.tsx
+++ b/src/pages/admin/PlayersTeams.tsx
@@ -5,6 +5,7 @@ import PlayerList from '@/components/players-teams/PlayerList'
 import TeamForm from '@/components/players-teams/TeamForm'
 import PlayerForm from '@/components/players-teams/PlayerForm'
 import LabelFilterChips from '@/components/players-teams/LabelFilterChips'
+import ScanQrModal from '@/components/players-teams/ScanQrModal'
 import { Button } from '@/components/ui'
 
 type TabId = 'teams' | 'players'
@@ -27,6 +28,13 @@ export default function PlayersTeams() {
 
   // ── Mobile tab ──────────────────────────────────────────────────────────────
   const [activeTab, setActiveTab] = useState<TabId>('teams')
+  const [scanOpen, setScanOpen] = useState(false)
+  const [, setHighlightedIds] = useState<Set<string>>(new Set())
+
+  function handleImported(playerIds: string[]) {
+    setHighlightedIds(new Set(playerIds))
+    setTimeout(() => setHighlightedIds(new Set()), 3000)
+  }
 
   function handleSelectTeam(teamId: string | null) {
     setSelectedTeamId(teamId)
@@ -43,7 +51,7 @@ export default function PlayersTeams() {
       {/* ── Shared header ───────────────────────────────────────────────────── */}
       <div className="flex items-center gap-3 mb-4 -mt-2" aria-label="Players and Teams actions">
         <div className="flex-1" />
-        <Button variant="secondary" size="sm">
+        <Button variant="secondary" size="sm" onClick={() => setScanOpen(true)}>
           ⌖ Scan QR
         </Button>
         <Button
@@ -97,7 +105,7 @@ export default function PlayersTeams() {
           aria-label="Teams pane"
         >
           <PaneHeader
-            title={selectedTeamId ? 'Teams' : 'Teams'}
+            title="Teams"
             search={teamSearch}
             onSearch={setTeamSearch}
             searchPlaceholder="Search teams..."
@@ -151,6 +159,7 @@ export default function PlayersTeams() {
         defaultTeamId={selectedTeamId ?? undefined}
         onClose={() => setPlayerFormOpen(false)}
       />
+      <ScanQrModal open={scanOpen} onClose={() => setScanOpen(false)} onImported={handleImported} />
     </AdminLayout>
   )
 }

--- a/src/test/players-teams/QrScan.test.tsx
+++ b/src/test/players-teams/QrScan.test.tsx
@@ -1,0 +1,442 @@
+// @vitest-pool vmForks
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { db } from '@/db'
+import {
+  detectPlayerConflict,
+  importPlayerDirect,
+  applyPlayerMerge,
+  importTeamQr,
+  resolveOrCreateLabels,
+} from '@/components/players-teams/qrImport'
+import type { PlayerQrPayload, TeamQrPayload } from '@/types/players-teams'
+import PlayerMergeModal from '@/components/players-teams/PlayerMergeModal'
+
+async function clearAll() {
+  await Promise.all([db.managedPlayers.clear(), db.managedTeams.clear(), db.managedLabels.clear()])
+}
+
+function renderInRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+// ── resolveOrCreateLabels ─────────────────────────────────────────────────────
+
+describe('resolveOrCreateLabels', () => {
+  beforeEach(clearAll)
+
+  it('returns empty array for empty input', async () => {
+    expect(await resolveOrCreateLabels([])).toEqual([])
+  })
+
+  it('creates a label that does not exist and returns its ID', async () => {
+    const ids = await resolveOrCreateLabels(['Trivia'])
+    expect(ids).toHaveLength(1)
+    const label = await db.managedLabels.get(ids[0])
+    expect(label?.name).toBe('Trivia')
+  })
+
+  it('reuses an existing label by name (case-insensitive)', async () => {
+    await db.managedLabels.add({ id: 'l1', name: 'Trivia', color: '#6366f1' })
+    const ids = await resolveOrCreateLabels(['trivia'])
+    expect(ids).toEqual(['l1'])
+    expect(await db.managedLabels.count()).toBe(1) // no new label created
+  })
+
+  it('handles a mix of existing and new labels', async () => {
+    await db.managedLabels.add({ id: 'l1', name: 'Sports', color: '#e67e22' })
+    const ids = await resolveOrCreateLabels(['Sports', 'NewLabel'])
+    expect(ids).toContain('l1')
+    expect(ids).toHaveLength(2)
+    expect(await db.managedLabels.count()).toBe(2)
+  })
+})
+
+// ── detectPlayerConflict ──────────────────────────────────────────────────────
+
+describe('detectPlayerConflict', () => {
+  beforeEach(clearAll)
+
+  it('returns null when no existing player matches', async () => {
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p-new',
+      name: 'Ana',
+      labels: [],
+    }
+    expect(await detectPlayerConflict(payload)).toBeNull()
+  })
+
+  it('detects conflict by ID', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ana',
+      labels: [],
+    }
+    const conflict = await detectPlayerConflict(payload)
+    expect(conflict).not.toBeNull()
+    expect(conflict!.existing.id).toBe('p1')
+  })
+
+  it('detects conflict by name (case-insensitive)', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana Kovac',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p-other',
+      name: 'ana kovac',
+      labels: [],
+    }
+    const conflict = await detectPlayerConflict(payload)
+    expect(conflict).not.toBeNull()
+  })
+
+  it('includes name diff when names differ', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ana K.',
+      labels: [],
+    }
+    const conflict = await detectPlayerConflict(payload)
+    expect(conflict!.diffs.some(d => d.field === 'name')).toBe(true)
+  })
+
+  it('includes labels diff when labels differ', async () => {
+    await db.managedLabels.add({ id: 'l1', name: 'Sports', color: '#e67e22' })
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ben',
+      teamIds: [],
+      labelIds: ['l1'],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ben',
+      labels: ['Trivia'],
+    }
+    const conflict = await detectPlayerConflict(payload)
+    expect(conflict!.diffs.some(d => d.field === 'labels')).toBe(true)
+  })
+
+  it('returns empty diffs when records are identical', async () => {
+    await db.managedLabels.add({ id: 'l1', name: 'Sports', color: '#e67e22' })
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ben',
+      teamIds: [],
+      labelIds: ['l1'],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ben',
+      labels: ['Sports'],
+    }
+    const conflict = await detectPlayerConflict(payload)
+    expect(conflict!.diffs).toHaveLength(0)
+  })
+})
+
+// ── importPlayerDirect ────────────────────────────────────────────────────────
+
+describe('importPlayerDirect', () => {
+  beforeEach(clearAll)
+
+  it('creates a new player with no labels', async () => {
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Clara',
+      labels: [],
+    }
+    const id = await importPlayerDirect(payload)
+    const player = await db.managedPlayers.get(id)
+    expect(player?.name).toBe('Clara')
+    expect(player?.labelIds).toHaveLength(0)
+    expect(player?.archivedAt).toBeNull()
+  })
+
+  it('creates labels that do not exist and assigns them', async () => {
+    const payload: PlayerQrPayload = {
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Dave',
+      labels: ['Trivia'],
+    }
+    const id = await importPlayerDirect(payload)
+    const player = await db.managedPlayers.get(id)
+    expect(player?.labelIds).toHaveLength(1)
+    const label = await db.managedLabels.get(player!.labelIds[0])
+    expect(label?.name).toBe('Trivia')
+  })
+})
+
+// ── applyPlayerMerge ──────────────────────────────────────────────────────────
+
+describe('applyPlayerMerge', () => {
+  beforeEach(clearAll)
+
+  it('keeps current name when choice is current', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const conflict = (await detectPlayerConflict({
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ana K.',
+      labels: [],
+    }))!
+    await applyPlayerMerge(conflict, { name: 'current', labels: 'current' })
+    const player = await db.managedPlayers.get('p1')
+    expect(player?.name).toBe('Ana')
+  })
+
+  it('updates name when choice is incoming', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const conflict = (await detectPlayerConflict({
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ana K.',
+      labels: [],
+    }))!
+    await applyPlayerMerge(conflict, { name: 'incoming', labels: 'current' })
+    const player = await db.managedPlayers.get('p1')
+    expect(player?.name).toBe('Ana K.')
+  })
+
+  it('updates labels when choice is incoming', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ben',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const conflict = (await detectPlayerConflict({
+      type: 'viktorani/player/v1',
+      id: 'p1',
+      name: 'Ben',
+      labels: ['Trivia'],
+    }))!
+    await applyPlayerMerge(conflict, { name: 'current', labels: 'incoming' })
+    const player = await db.managedPlayers.get('p1')
+    expect(player?.labelIds).toHaveLength(1)
+  })
+})
+
+// ── importTeamQr ──────────────────────────────────────────────────────────────
+
+describe('importTeamQr', () => {
+  beforeEach(clearAll)
+
+  it('creates a new team with no players', async () => {
+    const payload: TeamQrPayload = {
+      type: 'viktorani/team/v1',
+      id: 't1',
+      name: 'Blue Shield',
+      color: '#3a57b7',
+      icon: 'Shield',
+      labels: [],
+      players: [],
+    }
+    const result = await importTeamQr(payload)
+    expect(result.teamId).toBe('t1')
+    const team = await db.managedTeams.get('t1')
+    expect(team?.name).toBe('Blue Shield')
+  })
+
+  it('imports embedded players and links them to the team', async () => {
+    const payload: TeamQrPayload = {
+      type: 'viktorani/team/v1',
+      id: 't1',
+      name: 'Blue Shield',
+      color: '#3a57b7',
+      icon: 'Shield',
+      labels: [],
+      players: [
+        { id: 'p1', name: 'Ana' },
+        { id: 'p2', name: 'Ben' },
+      ],
+    }
+    const result = await importTeamQr(payload)
+    expect(result.createdPlayerIds).toHaveLength(2)
+    const team = await db.managedTeams.get('t1')
+    expect(team?.playerIds).toContain('p1')
+    expect(team?.playerIds).toContain('p2')
+  })
+
+  it('detects conflict for an existing player in the roster', async () => {
+    await db.managedPlayers.add({
+      id: 'p1',
+      name: 'Ana',
+      teamIds: [],
+      labelIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: TeamQrPayload = {
+      type: 'viktorani/team/v1',
+      id: 't1',
+      name: 'Blue Shield',
+      color: '#3a57b7',
+      icon: 'Shield',
+      labels: [],
+      players: [{ id: 'p1', name: 'Ana Different' }],
+    }
+    const result = await importTeamQr(payload)
+    expect(result.pendingConflicts).toHaveLength(1)
+    expect(result.createdPlayerIds).toHaveLength(0)
+  })
+
+  it('upserts an existing team on re-import', async () => {
+    await db.managedTeams.add({
+      id: 't1',
+      name: 'Old Name',
+      color: '#000',
+      icon: 'Flag',
+      labelIds: [],
+      playerIds: [],
+      archivedAt: null,
+      totalScore: 0,
+      gameLog: [],
+    })
+    const payload: TeamQrPayload = {
+      type: 'viktorani/team/v1',
+      id: 't1',
+      name: 'New Name',
+      color: '#3a57b7',
+      icon: 'Shield',
+      labels: [],
+      players: [],
+    }
+    await importTeamQr(payload)
+    const team = await db.managedTeams.get('t1')
+    expect(team?.name).toBe('New Name')
+    expect(team?.color).toBe('#3a57b7')
+  })
+})
+
+// ── PlayerMergeModal ──────────────────────────────────────────────────────────
+
+describe('PlayerMergeModal', () => {
+  it('shows diff fields with radio buttons', async () => {
+    const conflict = {
+      existing: {
+        id: 'p1',
+        name: 'Ana',
+        teamIds: [],
+        labelIds: [],
+        archivedAt: null,
+        totalScore: 0,
+        gameLog: [],
+      },
+      incoming: { type: 'viktorani/player/v1' as const, id: 'p1', name: 'Ana K.', labels: [] },
+      diffs: [{ field: 'name' as const, current: 'Ana', incoming: 'Ana K.' }],
+    }
+    const onApply = vi.fn()
+    renderInRouter(
+      <PlayerMergeModal open conflict={conflict} onApply={onApply} onCancel={() => {}} />
+    )
+    expect(screen.getByLabelText(/keep current name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/use incoming name/i)).toBeInTheDocument()
+  })
+
+  it('calls onApply with correct choices when Apply merge is clicked', async () => {
+    const conflict = {
+      existing: {
+        id: 'p1',
+        name: 'Ana',
+        teamIds: [],
+        labelIds: [],
+        archivedAt: null,
+        totalScore: 0,
+        gameLog: [],
+      },
+      incoming: { type: 'viktorani/player/v1' as const, id: 'p1', name: 'Ana K.', labels: [] },
+      diffs: [{ field: 'name' as const, current: 'Ana', incoming: 'Ana K.' }],
+    }
+    const onApply = vi.fn()
+    renderInRouter(
+      <PlayerMergeModal open conflict={conflict} onApply={onApply} onCancel={() => {}} />
+    )
+    fireEvent.click(screen.getByLabelText(/use incoming name/i))
+    fireEvent.click(screen.getByRole('button', { name: /apply merge/i }))
+    await waitFor(() => {
+      expect(onApply).toHaveBeenCalledWith({ name: 'incoming', labels: 'current' })
+    })
+  })
+
+  it('calls onCancel when Cancel is clicked', () => {
+    const conflict = {
+      existing: {
+        id: 'p1',
+        name: 'Ana',
+        teamIds: [],
+        labelIds: [],
+        archivedAt: null,
+        totalScore: 0,
+        gameLog: [],
+      },
+      incoming: { type: 'viktorani/player/v1' as const, id: 'p1', name: 'Ana K.', labels: [] },
+      diffs: [{ field: 'name' as const, current: 'Ana', incoming: 'Ana K.' }],
+    }
+    const onCancel = vi.fn()
+    renderInRouter(
+      <PlayerMergeModal open conflict={conflict} onApply={() => {}} onCancel={onCancel} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### QrScanner
  - Move BarcodeDetector check out of effect into component body so setStatus is not called synchronously inside an effect
  - Capture videoRef.current into a local variable before async work so the cleanup closure uses the stable reference
  - Add supported to the effect dependency array

### PlayerMergeModal
  - Add parentheses around the ?? expression to fix TS5076

### PlayersTeams
  - Fix useState destructuring: const [, setHighlightedIds] to discard the value and keep only the setter (avoids Set being mistaken for a call signature)
  - Remove unused teamId parameter from handleImported

Closes #116 