### PR TITLE
feat(gamemaster): player roster, team management, and away status

### DIFF
--- a/src/components/gamemaster/RosterPanel.tsx
+++ b/src/components/gamemaster/RosterPanel.tsx
@@ -1,0 +1,136 @@
+import { CircleDot, Circle, UserX } from 'lucide-react'
+import { Icon, Badge, Button } from '@/components/ui'
+import type { Player, Team } from '@/db'
+
+interface RosterPanelProps {
+  players: Player[]
+  teams: Team[]
+  onKick: (playerId: string) => void
+}
+
+/**
+ * Live roster panel for the GameMaster lobby.
+ * Shows each connected player's name, team badge, score, and online/away status.
+ * Provides a kick action that marks the player as away.
+ *
+ * Count badge in the header reflects only non-away (online) players.
+ */
+export function RosterPanel({ players, teams, onKick }: RosterPanelProps) {
+  const teamMap = new Map(teams.map(t => [t.id, t]))
+  const onlineCount = players.filter(p => !p.isAway).length
+
+  return (
+    <div
+      className="rounded-xl border flex flex-col"
+      style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+    >
+      {/* Header */}
+      <div
+        className="px-4 py-3 border-b flex items-center justify-between"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <span
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--color-muted)' }}
+        >
+          Players
+        </span>
+        <span
+          className="text-xs font-bold px-2 py-0.5 rounded-full"
+          style={{
+            background: onlineCount > 0 ? 'var(--color-green)22' : 'var(--color-border)',
+            color: onlineCount > 0 ? 'var(--color-green)' : 'var(--color-muted)',
+          }}
+          aria-live="polite"
+          aria-label={`${onlineCount} player${onlineCount !== 1 ? 's' : ''} online`}
+        >
+          {onlineCount} online
+        </span>
+      </div>
+
+      {/* Player rows */}
+      <div className="flex-1 overflow-y-auto" style={{ maxHeight: 320 }}>
+        {players.length === 0 ? (
+          <div className="flex items-center justify-center py-10">
+            <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
+              No players yet
+            </p>
+          </div>
+        ) : (
+          players.map(player => {
+            const team = player.teamId ? teamMap.get(player.teamId) : undefined
+            return (
+              <div
+                key={player.id}
+                className="flex items-center gap-3 px-4 py-2.5 border-b last:border-b-0"
+                style={{ borderColor: 'var(--color-border)' }}
+              >
+                {/* Online/away dot */}
+                <span
+                  style={{ color: player.isAway ? 'var(--color-muted)' : 'var(--color-green)' }}
+                  aria-label={player.isAway ? 'Away' : 'Online'}
+                  className="shrink-0"
+                >
+                  <Icon
+                    icon={player.isAway ? Circle : CircleDot}
+                    size="sm"
+                    aria-hidden={false}
+                  />
+                </span>
+
+                {/* Name */}
+                <span
+                  className="flex-1 text-sm truncate"
+                  style={{ color: player.isAway ? 'var(--color-muted)' : 'var(--color-ink)' }}
+                >
+                  {player.name}
+                </span>
+
+                {/* Team badge */}
+                {team ? (
+                  <Badge
+                    style={{
+                      background: team.color + '22',
+                      color: team.color,
+                      border: `1px solid ${team.color}44`,
+                      maxWidth: 96,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {team.name}
+                  </Badge>
+                ) : (
+                  <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+                    no team
+                  </span>
+                )}
+
+                {/* Score */}
+                <span
+                  className="mono text-sm font-bold w-8 text-right shrink-0"
+                  style={{ color: 'var(--color-ink)' }}
+                >
+                  {player.score}
+                </span>
+
+                {/* Kick button */}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onKick(player.id)}
+                  aria-label={`Kick ${player.name}`}
+                  title={`Kick ${player.name}`}
+                  style={{ color: 'var(--color-red)', padding: '0.25rem' }}
+                >
+                  <Icon icon={UserX} size="sm" aria-hidden />
+                </Button>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/gamemaster/RosterPanel.tsx
+++ b/src/components/gamemaster/RosterPanel.tsx
@@ -1,5 +1,5 @@
 import { CircleDot, Circle, UserX } from 'lucide-react'
-import { Icon, Badge, Button } from '@/components/ui'
+import { Icon, Button } from '@/components/ui'
 import { resolveIcon } from '@/components/players-teams/teamIcons'
 import type { Player, Team } from '@/db'
 
@@ -72,11 +72,7 @@ export function RosterPanel({ players, teams, onKick }: RosterPanelProps) {
                   aria-label={player.isAway ? 'Away' : 'Online'}
                   className="shrink-0"
                 >
-                  <Icon
-                    icon={player.isAway ? Circle : CircleDot}
-                    size="sm"
-                    aria-hidden={false}
-                  />
+                  <Icon icon={player.isAway ? Circle : CircleDot} size="sm" aria-hidden={false} />
                 </span>
 
                 {/* Name */}

--- a/src/components/gamemaster/RosterPanel.tsx
+++ b/src/components/gamemaster/RosterPanel.tsx
@@ -1,5 +1,6 @@
 import { CircleDot, Circle, UserX } from 'lucide-react'
 import { Icon, Badge, Button } from '@/components/ui'
+import { resolveIcon } from '@/components/players-teams/teamIcons'
 import type { Player, Team } from '@/db'
 
 interface RosterPanelProps {
@@ -88,19 +89,13 @@ export function RosterPanel({ players, teams, onKick }: RosterPanelProps) {
 
                 {/* Team badge */}
                 {team ? (
-                  <Badge
-                    style={{
-                      background: team.color + '22',
-                      color: team.color,
-                      border: `1px solid ${team.color}44`,
-                      maxWidth: 96,
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                    }}
+                  <span
+                    className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium text-white shrink-0"
+                    style={{ background: team.color, maxWidth: 108 }}
                   >
-                    {team.name}
-                  </Badge>
+                    <Icon icon={resolveIcon(team.icon)} size="sm" aria-hidden />
+                    <span className="truncate">{team.name}</span>
+                  </span>
                 ) : (
                   <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
                     no team

--- a/src/components/gamemaster/TeamManagerPanel.tsx
+++ b/src/components/gamemaster/TeamManagerPanel.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react'
+import { Plus } from 'lucide-react'
+import { Icon, Button, Input } from '@/components/ui'
+import { canCreateTeam, canAssignToTeam } from '@/pages/admin/gamemaster-utils'
+import type { Game, Player, Team } from '@/db'
+
+// Palette of quick-select colours for new teams
+const TEAM_COLOURS = [
+  '#e74c3c',
+  '#e67e22',
+  '#f1c40f',
+  '#2ecc71',
+  '#1abc9c',
+  '#3498db',
+  '#9b59b6',
+  '#e91e8c',
+  '#607d8b',
+  '#795548',
+]
+
+interface TeamManagerPanelProps {
+  game: Game
+  teams: Team[]
+  players: Player[]
+  onCreateTeam: (name: string, color: string) => Promise<void>
+  onAssignPlayer: (playerId: string, teamId: string | null) => Promise<void>
+}
+
+/**
+ * Panel for the GM to manage session teams during the lobby phase.
+ *
+ * - Create a new team with a name and colour (respects `game.maxTeams` cap).
+ * - Assign any player to a team via a dropdown (respects `game.maxPerTeam` cap).
+ * - Players can be removed from a team by selecting "No team".
+ */
+export function TeamManagerPanel({
+  game,
+  teams,
+  players,
+  onCreateTeam,
+  onAssignPlayer,
+}: TeamManagerPanelProps) {
+  const [newName, setNewName] = useState('')
+  const [newColor, setNewColor] = useState(TEAM_COLOURS[0])
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const teamAtCap = !canCreateTeam(game, teams.length)
+
+  async function handleCreate() {
+    const trimmed = newName.trim()
+    if (!trimmed) return
+    if (teamAtCap) return
+    setCreating(true)
+    setError(null)
+    try {
+      await onCreateTeam(trimmed, newColor)
+      setNewName('')
+      setNewColor(TEAM_COLOURS[0])
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create team')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div
+      className="rounded-xl border flex flex-col gap-0"
+      style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+    >
+      {/* Header */}
+      <div
+        className="px-4 py-3 border-b flex items-center justify-between"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        <span
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--color-muted)' }}
+        >
+          Teams
+        </span>
+        {game.maxTeams > 0 && (
+          <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+            {teams.length} / {game.maxTeams}
+          </span>
+        )}
+      </div>
+
+      {/* Existing teams */}
+      {teams.length > 0 && (
+        <div className="flex flex-col divide-y" style={{ borderColor: 'var(--color-border)' }}>
+          {teams.map(team => {
+            const memberCount = players.filter(p => p.teamId === team.id).length
+            return (
+              <div
+                key={team.id}
+                className="flex items-center gap-3 px-4 py-2.5"
+              >
+                <span
+                  className="w-3 h-3 rounded-full shrink-0"
+                  style={{ background: team.color }}
+                  aria-hidden
+                />
+                <span className="flex-1 text-sm font-medium truncate">{team.name}</span>
+                <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+                  {memberCount} player{memberCount !== 1 ? 's' : ''}
+                  {game.maxPerTeam > 0 && ` / ${game.maxPerTeam}`}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Assign player to team */}
+      {players.length > 0 && teams.length > 0 && (
+        <div
+          className="px-4 py-3 border-t flex flex-col gap-2"
+          style={{ borderColor: 'var(--color-border)' }}
+        >
+          <span className="text-xs font-semibold" style={{ color: 'var(--color-muted)' }}>
+            Assign player
+          </span>
+          {players.map(player => {
+            return (
+              <div key={player.id} className="flex items-center gap-2">
+                <span className="text-sm flex-1 truncate">{player.name}</span>
+                <select
+                  value={player.teamId ?? ''}
+                  onChange={e => void onAssignPlayer(player.id, e.target.value || null)}
+                  className="text-xs rounded border px-2 py-1"
+                  style={{
+                    borderColor: 'var(--color-border)',
+                    background: 'var(--color-cream)',
+                    color: 'var(--color-ink)',
+                    maxWidth: 140,
+                  }}
+                  aria-label={`Assign ${player.name} to team`}
+                >
+                  <option value="">No team</option>
+                  {teams.map(team => {
+                    const blocked =
+                      player.teamId !== team.id &&
+                      !canAssignToTeam(game, team, players, player.id)
+                    return (
+                      <option key={team.id} value={team.id} disabled={blocked}>
+                        {team.name}
+                        {blocked ? ' (full)' : ''}
+                      </option>
+                    )
+                  })}
+                </select>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Create new team */}
+      <div
+        className="px-4 py-3 border-t flex flex-col gap-3"
+        style={{ borderColor: 'var(--color-border)' }}
+      >
+        {teamAtCap ? (
+          <p className="text-xs" style={{ color: 'var(--color-muted)' }}>
+            Team limit reached ({game.maxTeams})
+          </p>
+        ) : (
+          <>
+            <span className="text-xs font-semibold" style={{ color: 'var(--color-muted)' }}>
+              New team
+            </span>
+
+            {/* Colour picker */}
+            <div className="flex flex-wrap gap-1.5">
+              {TEAM_COLOURS.map(c => (
+                <button
+                  key={c}
+                  onClick={() => setNewColor(c)}
+                  className="w-6 h-6 rounded-full transition-transform"
+                  style={{
+                    background: c,
+                    outline: newColor === c ? `2px solid var(--color-ink)` : 'none',
+                    outlineOffset: 2,
+                    transform: newColor === c ? 'scale(1.2)' : 'scale(1)',
+                  }}
+                  aria-label={`Select colour ${c}`}
+                  aria-pressed={newColor === c}
+                />
+              ))}
+              {/* Custom hex input */}
+              <input
+                type="color"
+                value={newColor}
+                onChange={e => setNewColor(e.target.value)}
+                className="w-6 h-6 rounded cursor-pointer border"
+                style={{ borderColor: 'var(--color-border)', padding: 0 }}
+                title="Custom colour"
+                aria-label="Custom team colour"
+              />
+            </div>
+
+            {/* Name input + create button */}
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <Input
+                  label=""
+                  placeholder="Team name"
+                  value={newName}
+                  onChange={e => setNewName(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') void handleCreate()
+                  }}
+                  maxLength={40}
+                  aria-label="New team name"
+                />
+              </div>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={() => void handleCreate()}
+                disabled={creating || !newName.trim()}
+                aria-label="Create team"
+              >
+                <Icon icon={Plus} size="sm" />
+                {creating ? 'Creating...' : 'Create'}
+              </Button>
+            </div>
+
+            {error && (
+              <p className="text-xs" style={{ color: 'var(--color-red)' }}>
+                {error}
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/gamemaster/TeamManagerPanel.tsx
+++ b/src/components/gamemaster/TeamManagerPanel.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { Plus } from 'lucide-react'
-import { Icon, Button, Input } from '@/components/ui'
+import { Plus, Download } from 'lucide-react'
+import { Icon, Button, Input, Modal } from '@/components/ui'
 import { canCreateTeam, canAssignToTeam } from '@/pages/admin/gamemaster-utils'
+import { resolveIcon, TEAM_ICONS } from '@/components/players-teams/teamIcons'
 import type { Game, Player, Team } from '@/db'
 
 // Palette of quick-select colours for new teams
@@ -22,15 +23,17 @@ interface TeamManagerPanelProps {
   game: Game
   teams: Team[]
   players: Player[]
-  onCreateTeam: (name: string, color: string) => Promise<void>
+  onCreateTeam: (name: string, color: string, icon: string) => Promise<void>
   onAssignPlayer: (playerId: string, teamId: string | null) => Promise<void>
+  onImportFromManaged: () => Promise<void>
 }
 
 /**
  * Panel for the GM to manage session teams during the lobby phase.
  *
- * - Create a new team with a name and colour (respects `game.maxTeams` cap).
- * - Assign any player to a team via a dropdown (respects `game.maxPerTeam` cap).
+ * - Import teams (and their players) from the Players & Teams management page.
+ * - Create a new team with a name, colour, and icon (respects game.maxTeams cap).
+ * - Assign any player to a team via a dropdown (respects game.maxPerTeam cap).
  * - Players can be removed from a team by selecting "No team".
  */
 export function TeamManagerPanel({
@@ -39,13 +42,18 @@ export function TeamManagerPanel({
   players,
   onCreateTeam,
   onAssignPlayer,
+  onImportFromManaged,
 }: TeamManagerPanelProps) {
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState(TEAM_COLOURS[0])
+  const [newIcon, setNewIcon] = useState('Shield')
   const [creating, setCreating] = useState(false)
+  const [importing, setImporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [showIconPicker, setShowIconPicker] = useState(false)
 
   const teamAtCap = !canCreateTeam(game, teams.length)
+  const SelectedIcon = resolveIcon(newIcon)
 
   async function handleCreate() {
     const trimmed = newName.trim()
@@ -54,9 +62,10 @@ export function TeamManagerPanel({
     setCreating(true)
     setError(null)
     try {
-      await onCreateTeam(trimmed, newColor)
+      await onCreateTeam(trimmed, newColor, newIcon)
       setNewName('')
       setNewColor(TEAM_COLOURS[0])
+      setNewIcon('Shield')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to create team')
     } finally {
@@ -64,9 +73,21 @@ export function TeamManagerPanel({
     }
   }
 
+  async function handleImport() {
+    setImporting(true)
+    setError(null)
+    try {
+      await onImportFromManaged()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Import failed')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   return (
     <div
-      className="rounded-xl border flex flex-col gap-0"
+      className="rounded-xl border flex flex-col"
       style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
     >
       {/* Header */}
@@ -80,32 +101,49 @@ export function TeamManagerPanel({
         >
           Teams
         </span>
-        {game.maxTeams > 0 && (
-          <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
-            {teams.length} / {game.maxTeams}
-          </span>
-        )}
+        <div className="flex items-center gap-2">
+          {game.maxTeams > 0 && (
+            <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+              {teams.length} / {game.maxTeams}
+            </span>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void handleImport()}
+            disabled={importing}
+            title="Import teams and players from the Players & Teams page"
+          >
+            <Icon icon={Download} size="sm" />
+            {importing ? 'Importing...' : 'Import'}
+          </Button>
+        </div>
       </div>
 
       {/* Existing teams */}
       {teams.length > 0 && (
-        <div className="flex flex-col divide-y" style={{ borderColor: 'var(--color-border)' }}>
+        <div className="flex flex-col">
           {teams.map(team => {
+            const TeamIcon = resolveIcon(team.icon)
             const memberCount = players.filter(p => p.teamId === team.id).length
             return (
               <div
                 key={team.id}
-                className="flex items-center gap-3 px-4 py-2.5"
+                className="flex items-center gap-3 px-4 py-2.5 border-b"
+                style={{ borderColor: 'var(--color-border)' }}
               >
                 <span
-                  className="w-3 h-3 rounded-full shrink-0"
+                  className="w-6 h-6 rounded flex items-center justify-center shrink-0 text-white"
                   style={{ background: team.color }}
                   aria-hidden
-                />
+                >
+                  <Icon icon={TeamIcon} size="sm" />
+                </span>
                 <span className="flex-1 text-sm font-medium truncate">{team.name}</span>
-                <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
-                  {memberCount} player{memberCount !== 1 ? 's' : ''}
-                  {game.maxPerTeam > 0 && ` / ${game.maxPerTeam}`}
+                <span className="text-xs shrink-0" style={{ color: 'var(--color-muted)' }}>
+                  {memberCount}
+                  {game.maxPerTeam > 0 ? ` / ${game.maxPerTeam}` : ''}{' '}
+                  player{memberCount !== 1 ? 's' : ''}
                 </span>
               </div>
             )
@@ -116,52 +154,47 @@ export function TeamManagerPanel({
       {/* Assign player to team */}
       {players.length > 0 && teams.length > 0 && (
         <div
-          className="px-4 py-3 border-t flex flex-col gap-2"
+          className="px-4 py-3 border-b flex flex-col gap-2"
           style={{ borderColor: 'var(--color-border)' }}
         >
           <span className="text-xs font-semibold" style={{ color: 'var(--color-muted)' }}>
             Assign player
           </span>
-          {players.map(player => {
-            return (
-              <div key={player.id} className="flex items-center gap-2">
-                <span className="text-sm flex-1 truncate">{player.name}</span>
-                <select
-                  value={player.teamId ?? ''}
-                  onChange={e => void onAssignPlayer(player.id, e.target.value || null)}
-                  className="text-xs rounded border px-2 py-1"
-                  style={{
-                    borderColor: 'var(--color-border)',
-                    background: 'var(--color-cream)',
-                    color: 'var(--color-ink)',
-                    maxWidth: 140,
-                  }}
-                  aria-label={`Assign ${player.name} to team`}
-                >
-                  <option value="">No team</option>
-                  {teams.map(team => {
-                    const blocked =
-                      player.teamId !== team.id &&
-                      !canAssignToTeam(game, team, players, player.id)
-                    return (
-                      <option key={team.id} value={team.id} disabled={blocked}>
-                        {team.name}
-                        {blocked ? ' (full)' : ''}
-                      </option>
-                    )
-                  })}
-                </select>
-              </div>
-            )
-          })}
+          {players.map(player => (
+            <div key={player.id} className="flex items-center gap-2">
+              <span className="text-sm flex-1 truncate">{player.name}</span>
+              <select
+                value={player.teamId ?? ''}
+                onChange={e => void onAssignPlayer(player.id, e.target.value || null)}
+                className="text-xs rounded border px-2 py-1"
+                style={{
+                  borderColor: 'var(--color-border)',
+                  background: 'var(--color-cream)',
+                  color: 'var(--color-ink)',
+                  maxWidth: 140,
+                }}
+                aria-label={`Assign ${player.name} to team`}
+              >
+                <option value="">No team</option>
+                {teams.map(team => {
+                  const blocked =
+                    player.teamId !== team.id &&
+                    !canAssignToTeam(game, team, players, player.id)
+                  return (
+                    <option key={team.id} value={team.id} disabled={blocked}>
+                      {team.name}
+                      {blocked ? ' (full)' : ''}
+                    </option>
+                  )
+                })}
+              </select>
+            </div>
+          ))}
         </div>
       )}
 
       {/* Create new team */}
-      <div
-        className="px-4 py-3 border-t flex flex-col gap-3"
-        style={{ borderColor: 'var(--color-border)' }}
-      >
+      <div className="px-4 py-3 flex flex-col gap-3">
         {teamAtCap ? (
           <p className="text-xs" style={{ color: 'var(--color-muted)' }}>
             Team limit reached ({game.maxTeams})
@@ -172,36 +205,48 @@ export function TeamManagerPanel({
               New team
             </span>
 
-            {/* Colour picker */}
-            <div className="flex flex-wrap gap-1.5">
-              {TEAM_COLOURS.map(c => (
-                <button
-                  key={c}
-                  onClick={() => setNewColor(c)}
-                  className="w-6 h-6 rounded-full transition-transform"
-                  style={{
-                    background: c,
-                    outline: newColor === c ? `2px solid var(--color-ink)` : 'none',
-                    outlineOffset: 2,
-                    transform: newColor === c ? 'scale(1.2)' : 'scale(1)',
-                  }}
-                  aria-label={`Select colour ${c}`}
-                  aria-pressed={newColor === c}
+            {/* Colour swatches + icon picker trigger */}
+            <div className="flex items-center gap-3">
+              <div className="flex flex-wrap gap-1.5 flex-1">
+                {TEAM_COLOURS.map(c => (
+                  <button
+                    key={c}
+                    onClick={() => setNewColor(c)}
+                    className="w-5 h-5 rounded-full transition-transform"
+                    style={{
+                      background: c,
+                      outline: newColor === c ? `2px solid var(--color-ink)` : 'none',
+                      outlineOffset: 2,
+                      transform: newColor === c ? 'scale(1.2)' : 'scale(1)',
+                    }}
+                    aria-label={`Select colour ${c}`}
+                    aria-pressed={newColor === c}
+                  />
+                ))}
+                <input
+                  type="color"
+                  value={newColor}
+                  onChange={e => setNewColor(e.target.value)}
+                  className="w-5 h-5 rounded cursor-pointer border"
+                  style={{ borderColor: 'var(--color-border)', padding: 0 }}
+                  title="Custom colour"
+                  aria-label="Custom team colour"
                 />
-              ))}
-              {/* Custom hex input */}
-              <input
-                type="color"
-                value={newColor}
-                onChange={e => setNewColor(e.target.value)}
-                className="w-6 h-6 rounded cursor-pointer border"
-                style={{ borderColor: 'var(--color-border)', padding: 0 }}
-                title="Custom colour"
-                aria-label="Custom team colour"
-              />
+              </div>
+
+              {/* Live badge preview — click to pick icon */}
+              <button
+                onClick={() => setShowIconPicker(true)}
+                className="w-8 h-8 rounded flex items-center justify-center text-white shrink-0 transition-opacity hover:opacity-80"
+                style={{ background: newColor }}
+                title="Pick icon"
+                aria-label="Pick team icon"
+              >
+                <Icon icon={SelectedIcon} size="sm" />
+              </button>
             </div>
 
-            {/* Name input + create button */}
+            {/* Name + create */}
             <div className="flex items-end gap-2">
               <div className="flex-1">
                 <Input
@@ -236,6 +281,30 @@ export function TeamManagerPanel({
           </>
         )}
       </div>
+
+      {/* Icon picker modal */}
+      <Modal open={showIconPicker} onClose={() => setShowIconPicker(false)} title="Pick icon">
+        <div className="flex flex-wrap gap-2" style={{ maxHeight: 280, overflowY: 'auto' }}>
+          {TEAM_ICONS.map(({ key, icon: Ic }) => (
+            <button
+              key={key}
+              onClick={() => {
+                setNewIcon(key)
+                setShowIconPicker(false)
+              }}
+              className="w-9 h-9 rounded flex items-center justify-center transition-colors"
+              style={{
+                background: newIcon === key ? newColor : 'var(--color-border)',
+                color: newIcon === key ? '#fff' : 'var(--color-ink)',
+              }}
+              aria-label={key}
+              aria-pressed={newIcon === key}
+            >
+              <Icon icon={Ic} size="sm" />
+            </button>
+          ))}
+        </div>
+      </Modal>
     </div>
   )
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -189,6 +189,8 @@ export interface Team {
   gameId: string
   name: string
   color: string
+  /** Lucide icon key (e.g. 'Zap', 'Shield'). Defaults to 'Shield' if not set. */
+  icon: string
   score: number
 }
 

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { QRCodeSVG } from 'qrcode.react'
-import { QrCode, Rocket } from 'lucide-react'
+import { QrCode, Rocket, Copy, Check } from 'lucide-react'
 import AdminLayout from '@/components/AdminLayout'
 import { Button, TransportPill, Icon } from '@/components/ui'
 import { NavHeader } from '@/components/NavHeader'
@@ -55,8 +55,9 @@ interface LobbyProps {
   onStart: () => Promise<void>
   starting: boolean
   onKick: (playerId: string) => void
-  onCreateTeam: (name: string, color: string) => Promise<void>
+  onCreateTeam: (name: string, color: string, icon: string) => Promise<void>
   onAssignPlayer: (playerId: string, teamId: string | null) => Promise<void>
+  onImportFromManaged: () => Promise<void>
 }
 
 function Lobby({
@@ -72,10 +73,20 @@ function Lobby({
   onKick,
   onCreateTeam,
   onAssignPlayer,
+  onImportFromManaged,
 }: LobbyProps) {
   const activePlayers = players.filter(p => !p.isAway)
   const canStart = soloBypass || (status === 'connected' && activePlayers.length > 0)
   const url = game.roomId ? joinUrl(game.roomId) : ''
+  const [copied, setCopied] = useState(false)
+
+  function handleCopyUrl() {
+    if (!url) return
+    void navigator.clipboard.writeText(url).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
 
   return (
     <div className="max-w-3xl mx-auto flex flex-col gap-8 py-6">
@@ -135,7 +146,7 @@ function Lobby({
           )}
 
           {game.roomId && (
-            <div className="text-center">
+            <div className="text-center w-full">
               <p className="text-xs mb-1" style={{ color: 'var(--color-muted)' }}>
                 Room code
               </p>
@@ -145,6 +156,33 @@ function Lobby({
               >
                 {game.roomId}
               </p>
+
+              {/* Join URL + copy */}
+              <div
+                className="mt-3 flex items-center gap-1.5 rounded-lg px-3 py-1.5 w-full"
+                style={{ background: 'var(--color-border)' }}
+              >
+                <span
+                  className="flex-1 text-xs truncate text-left mono"
+                  style={{ color: 'var(--color-muted)' }}
+                  title={url}
+                >
+                  {url}
+                </span>
+                <button
+                  onClick={handleCopyUrl}
+                  className="shrink-0 flex items-center gap-1 text-xs px-2 py-1 rounded transition-colors"
+                  style={{
+                    background: copied ? 'var(--color-green)22' : 'transparent',
+                    color: copied ? 'var(--color-green)' : 'var(--color-muted)',
+                  }}
+                  aria-label={copied ? 'Copied!' : 'Copy join URL'}
+                  title={copied ? 'Copied!' : 'Copy join URL'}
+                >
+                  <Icon icon={copied ? Check : Copy} size="sm" />
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
             </div>
           )}
         </div>
@@ -158,6 +196,7 @@ function Lobby({
             players={players}
             onCreateTeam={onCreateTeam}
             onAssignPlayer={onAssignPlayer}
+            onImportFromManaged={onImportFromManaged}
           />
         </div>
       </div>
@@ -529,7 +568,7 @@ export default function GameMaster() {
 
   // Create a session team, persist to DB, broadcast GAME_STATE
   const handleCreateTeam = useCallback(
-    async (name: string, color: string) => {
+    async (name: string, color: string, icon: string) => {
       const g = gameRef.current
       if (!g) return
       const team: Team = {
@@ -537,16 +576,65 @@ export default function GameMaster() {
         gameId: g.id,
         name,
         color,
+        icon,
         score: 0,
       }
       await db.teams.add(team)
-      setTeams(prev => {
-        const updated = [...prev, team]
-        return updated
-      })
+      setTeams(prev => [...prev, team])
     },
     []
   )
+
+  // Import all active managed teams (and their players) into the session
+  const handleImportFromManaged = useCallback(async () => {
+    const g = gameRef.current
+    if (!g) return
+
+    const [managedTeams, managedPlayers] = await Promise.all([
+      db.managedTeams.filter(t => !t.archivedAt).toArray(),
+      db.managedPlayers.filter(p => !p.archivedAt).toArray(),
+    ])
+
+    // Upsert teams — skip any already in the session (by id)
+    const existingTeamIds = new Set((await db.teams.where('gameId').equals(g.id).toArray()).map(t => t.id))
+    const newTeams: Team[] = managedTeams
+      .filter(mt => !existingTeamIds.has(mt.id))
+      .map(mt => ({
+        id: mt.id,
+        gameId: g.id,
+        name: mt.name,
+        color: mt.color,
+        icon: mt.icon,
+        score: 0,
+      }))
+    if (newTeams.length > 0) await db.teams.bulkAdd(newTeams)
+
+    // Upsert players — skip any already in the session (by id)
+    const existingPlayerIds = new Set((await db.players.where('gameId').equals(g.id).toArray()).map(p => p.id))
+    const now = Date.now()
+    const newPlayers: import('@/db').Player[] = managedPlayers
+      .filter(mp => !existingPlayerIds.has(mp.id))
+      .map((mp, i) => ({
+        id: mp.id,
+        gameId: g.id,
+        name: mp.name,
+        // Assign to first matching session team
+        teamId: mp.teamIds.find(tid => managedTeams.some(mt => mt.id === tid)) ?? null,
+        score: 0,
+        isAway: false,
+        deviceId: '',
+        joinedAt: now + i,
+      }))
+    if (newPlayers.length > 0) await db.players.bulkAdd(newPlayers)
+
+    // Refresh state
+    const [freshTeams, freshPlayers] = await Promise.all([
+      db.teams.where('gameId').equals(g.id).toArray(),
+      db.players.where('gameId').equals(g.id).toArray(),
+    ])
+    setTeams(freshTeams)
+    setPlayers(freshPlayers.sort((a, b) => a.joinedAt - b.joinedAt))
+  }, [])
 
   // Assign a player to a team (or clear), persist to DB, broadcast GAME_STATE
   const handleAssignPlayer = useCallback(
@@ -620,6 +708,7 @@ export default function GameMaster() {
           onKick={handleKick}
           onCreateTeam={handleCreateTeam}
           onAssignPlayer={handleAssignPlayer}
+          onImportFromManaged={handleImportFromManaged}
         />
       </AdminLayout>
     )

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -1,22 +1,30 @@
 import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { QRCodeSVG } from 'qrcode.react'
-import { QrCode, Rocket, Hourglass, CircleDot, Circle } from 'lucide-react'
+import { QrCode, Rocket } from 'lucide-react'
 import AdminLayout from '@/components/AdminLayout'
-import { Button, Badge, TransportPill, Icon } from '@/components/ui'
+import { Button, TransportPill, Icon } from '@/components/ui'
 import { NavHeader } from '@/components/NavHeader'
 import { RoundBoundary } from '@/components/RoundBoundary'
 import { BuzzerPanel } from '@/components/buzzer/BuzzerPanel'
 import { ScoreboardPanel } from '@/components/scoreboard/ScoreboardPanel'
+import { RosterPanel } from '@/components/gamemaster/RosterPanel'
+import { TeamManagerPanel } from '@/components/gamemaster/TeamManagerPanel'
 import { db } from '@/db'
 import { transportManager } from '@/transport'
-import { serialiseGameState, upsertPlayer, markPlayerAway } from '@/pages/admin/gamemaster-utils'
+import {
+  serialiseGameState,
+  upsertPlayer,
+  markPlayerAway,
+  setPlayerAway,
+  assignPlayerTeam,
+} from '@/pages/admin/gamemaster-utils'
 import { useNavigation } from '@/hooks/useNavigation'
 import { useKeyNav } from '@/hooks/useKeyNav'
 import { useBuzzer } from '@/hooks/useBuzzer'
 import { useTimerList, applyAutoReset } from '@/hooks/useTimer'
 import { TimerPanel } from '@/components/timer/TimerPanel'
-import type { Game, Player } from '@/db'
+import type { Game, Player, Team } from '@/db'
 import type { TransportStatus, TransportType, TransportEvent } from '@/transport/types'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -34,54 +42,36 @@ const STATUS_LABEL: Record<TransportStatus, string> = {
   error: 'Connection error',
 }
 
-// ── Player row ────────────────────────────────────────────────────────────────
-
-function PlayerRow({ player }: { player: Player }) {
-  return (
-    <div
-      className="flex items-center gap-3 px-4 py-2.5 border-b last:border-b-0"
-      style={{ borderColor: 'var(--color-border)' }}
-    >
-      <Icon
-        icon={player.isAway ? Circle : CircleDot}
-        size="sm"
-        className="shrink-0"
-        aria-hidden={false}
-        aria-label={player.isAway ? 'Away' : 'Online'}
-        // colour via inline style since CSS vars aren't Tailwind classes
-      />
-      <span className="flex-1 text-sm">{player.name}</span>
-      {player.isAway && (
-        <Badge style={{ background: 'var(--color-muted)22', color: 'var(--color-muted)' }}>
-          away
-        </Badge>
-      )}
-    </div>
-  )
-}
-
 // ── Lobby view ────────────────────────────────────────────────────────────────
 
 interface LobbyProps {
   game: Game
   players: Player[]
+  teams: Team[]
   status: TransportStatus
   type: TransportType
   soloBypass: boolean
   onToggleSolo: () => void
   onStart: () => Promise<void>
   starting: boolean
+  onKick: (playerId: string) => void
+  onCreateTeam: (name: string, color: string) => Promise<void>
+  onAssignPlayer: (playerId: string, teamId: string | null) => Promise<void>
 }
 
 function Lobby({
   game,
   players,
+  teams,
   status,
   type,
   soloBypass,
   onToggleSolo,
   onStart,
   starting,
+  onKick,
+  onCreateTeam,
+  onAssignPlayer,
 }: LobbyProps) {
   const activePlayers = players.filter(p => !p.isAway)
   const canStart = soloBypass || (status === 'connected' && activePlayers.length > 0)
@@ -159,45 +149,16 @@ function Lobby({
           )}
         </div>
 
-        {/* Player list */}
-        <div
-          className="rounded-xl border flex flex-col"
-          style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
-        >
-          <div
-            className="px-4 py-3 border-b flex items-center justify-between"
-            style={{ borderColor: 'var(--color-border)' }}
-          >
-            <span
-              className="text-xs font-semibold uppercase tracking-wider"
-              style={{ color: 'var(--color-muted)' }}
-            >
-              Players
-            </span>
-            <span
-              className="text-xs font-bold px-2 py-0.5 rounded-full"
-              style={{
-                background:
-                  activePlayers.length > 0 ? 'var(--color-green)22' : 'var(--color-border)',
-                color: activePlayers.length > 0 ? 'var(--color-green)' : 'var(--color-muted)',
-              }}
-            >
-              {activePlayers.length} online
-            </span>
-          </div>
-
-          <div className="flex-1 overflow-y-auto" style={{ maxHeight: 240 }}>
-            {players.length === 0 ? (
-              <div className="flex flex-col items-center justify-center gap-2 h-24">
-                <Icon icon={Hourglass} size="md" aria-hidden />
-                <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
-                  Waiting for players to join…
-                </p>
-              </div>
-            ) : (
-              players.map(p => <PlayerRow key={p.id} player={p} />)
-            )}
-          </div>
+        {/* Roster + team management */}
+        <div className="flex flex-col gap-4">
+          <RosterPanel players={players} teams={teams} onKick={onKick} />
+          <TeamManagerPanel
+            game={game}
+            teams={teams}
+            players={players}
+            onCreateTeam={onCreateTeam}
+            onAssignPlayer={onAssignPlayer}
+          />
         </div>
       </div>
 
@@ -433,6 +394,7 @@ export default function GameMaster() {
 
   const [game, setGame] = useState<Game | null>(null)
   const [players, setPlayers] = useState<Player[]>([])
+  const [teams, setTeams] = useState<Team[]>([])
   const [status, setStatus] = useState<TransportStatus>(transportManager.status)
   const [type, setType] = useState<TransportType>(transportManager.transportType)
   const [soloBypass, setSoloBypass] = useState(false)
@@ -442,7 +404,7 @@ export default function GameMaster() {
   const gameRef = useRef<Game | null>(null)
   gameRef.current = game
 
-  // Load game + existing players on mount
+  // Load game + existing players + teams on mount
   useEffect(() => {
     if (!id) return
     db.games.get(id).then(g => {
@@ -457,6 +419,11 @@ export default function GameMaster() {
       .equals(id)
       .toArray()
       .then(ps => setPlayers(ps.sort((a, b) => a.joinedAt - b.joinedAt)))
+    db.teams
+      .where('gameId')
+      .equals(id)
+      .toArray()
+      .then(ts => setTeams(ts))
   }, [id])
 
   // Connect transport when game is loaded
@@ -515,6 +482,11 @@ export default function GameMaster() {
       setPlayers(prev => markPlayerAway(prev, event.playerId))
     }
 
+    if (event.type === 'FOCUS_CHANGE') {
+      await db.players.update(event.playerId, { isAway: event.away })
+      setPlayers(prev => setPlayerAway(prev, event.playerId, event.away))
+    }
+
     if (event.type === 'BUZZ') {
       // Delegate to the ActiveGame's useBuzzer via window bridge
       const handler = (window as unknown as Record<string, unknown>)['__vkt_handleBuzz'] as
@@ -539,6 +511,57 @@ export default function GameMaster() {
   useEffect(() => {
     return transportManager.onEvent(handleEvent)
   }, [handleEvent])
+
+  // Kick player — mark as away in DB + state, broadcast updated game state
+  const handleKick = useCallback(
+    async (playerId: string) => {
+      const g = gameRef.current
+      if (!g) return
+      await db.players.update(playerId, { isAway: true })
+      setPlayers(prev => {
+        const updated = markPlayerAway(prev, playerId)
+        transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
+        return updated
+      })
+    },
+    []
+  )
+
+  // Create a session team, persist to DB, broadcast GAME_STATE
+  const handleCreateTeam = useCallback(
+    async (name: string, color: string) => {
+      const g = gameRef.current
+      if (!g) return
+      const team: Team = {
+        id: crypto.randomUUID(),
+        gameId: g.id,
+        name,
+        color,
+        score: 0,
+      }
+      await db.teams.add(team)
+      setTeams(prev => {
+        const updated = [...prev, team]
+        return updated
+      })
+    },
+    []
+  )
+
+  // Assign a player to a team (or clear), persist to DB, broadcast GAME_STATE
+  const handleAssignPlayer = useCallback(
+    async (playerId: string, teamId: string | null) => {
+      const g = gameRef.current
+      if (!g) return
+      await db.players.update(playerId, { teamId })
+      setPlayers(prev => {
+        const updated = assignPlayerTeam(prev, playerId, teamId)
+        transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
+        return updated
+      })
+    },
+    []
+  )
 
   // Start the game
   async function handleStart() {
@@ -587,12 +610,16 @@ export default function GameMaster() {
         <Lobby
           game={game}
           players={players}
+          teams={teams}
           status={status}
           type={type}
           soloBypass={soloBypass}
           onToggleSolo={() => setSoloBypass(s => !s)}
           onStart={handleStart}
           starting={starting}
+          onKick={handleKick}
+          onCreateTeam={handleCreateTeam}
+          onAssignPlayer={handleAssignPlayer}
         />
       </AdminLayout>
     )

--- a/src/pages/admin/gamemaster-utils.ts
+++ b/src/pages/admin/gamemaster-utils.ts
@@ -1,4 +1,4 @@
-import type { Game, Player } from '@/db'
+import type { Game, Player, Team } from '@/db'
 import type { SerializedGameState } from '@/transport/types'
 
 /**
@@ -73,6 +73,56 @@ export function upsertPlayer(
  */
 export function markPlayerAway(players: Player[], playerId: string): Player[] {
   return players.map(p => (p.id === playerId ? { ...p, isAway: true } : p))
+}
+
+/**
+ * Sets a player's isAway flag (on or off) in a player list. Returns a new array.
+ */
+export function setPlayerAway(players: Player[], playerId: string, away: boolean): Player[] {
+  return players.map(p => (p.id === playerId ? { ...p, isAway: away } : p))
+}
+
+/**
+ * Assigns a player to a team (or clears the team when teamId is null).
+ * Returns a new array with the player's teamId updated.
+ */
+export function assignPlayerTeam(
+  players: Player[],
+  playerId: string,
+  teamId: string | null
+): Player[] {
+  return players.map(p => (p.id === playerId ? { ...p, teamId } : p))
+}
+
+// ── Cap enforcement ───────────────────────────────────────────────────────────
+
+/**
+ * Returns true when a new team may be created given the current game config
+ * and the number of existing teams.
+ *
+ * `maxTeams === 0` means unlimited.
+ */
+export function canCreateTeam(game: Pick<Game, 'maxTeams'>, currentTeamCount: number): boolean {
+  if (game.maxTeams === 0) return true
+  return currentTeamCount < game.maxTeams
+}
+
+/**
+ * Returns true when `playerId` may be assigned to `team`.
+ *
+ * Checks:
+ * - `maxPerTeam === 0` means unlimited.
+ * - Does not double-count the player if they are already on this team.
+ */
+export function canAssignToTeam(
+  game: Pick<Game, 'maxPerTeam'>,
+  team: Team,
+  players: Player[],
+  playerId: string
+): boolean {
+  if (game.maxPerTeam === 0) return true
+  const members = players.filter(p => p.teamId === team.id && p.id !== playerId)
+  return members.length < game.maxPerTeam
 }
 
 // ── Navigation types ──────────────────────────────────────────────────────────

--- a/src/test/db.test.ts
+++ b/src/test/db.test.ts
@@ -277,8 +277,22 @@ describe('DB schema', () => {
   })
 
   it('queries teams by gameId', async () => {
-    await db.teams.add({ id: 't1', gameId: 'g1', name: 'Red Team', color: '#f00', score: 0 })
-    await db.teams.add({ id: 't2', gameId: 'g2', name: 'Blue Team', color: '#00f', score: 0 })
+    await db.teams.add({
+      id: 't1',
+      gameId: 'g1',
+      icon: 'shield',
+      name: 'Red Team',
+      color: '#f00',
+      score: 0,
+    })
+    await db.teams.add({
+      id: 't2',
+      gameId: 'g2',
+      icon: 'star',
+      name: 'Blue Team',
+      color: '#00f',
+      score: 0,
+    })
     const teams = await db.teams.where('gameId').equals('g1').toArray()
     expect(teams).toHaveLength(1)
     expect(teams[0].name).toBe('Red Team')

--- a/src/test/gamemaster-roster.test.ts
+++ b/src/test/gamemaster-roster.test.ts
@@ -160,14 +160,20 @@ describe('canAssignToTeam', () => {
 
   it('returns false when team is at cap', () => {
     const team = makeTeam({ id: 't1' })
-    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
+    const players = [
+      makePlayer({ id: 'p1', teamId: 't1' }),
+      makePlayer({ id: 'p2', teamId: 't1' }),
+    ]
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p3')).toBe(false)
   })
 
   it('does not double-count player already on the team', () => {
     // p1 is already on t1 — moving p1 from t1 to t1 should not count twice
     const team = makeTeam({ id: 't1' })
-    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
+    const players = [
+      makePlayer({ id: 'p1', teamId: 't1' }),
+      makePlayer({ id: 'p2', teamId: 't1' }),
+    ]
     // cap=2, p1 already on t1 — reassigning p1 should be allowed
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p1')).toBe(true)
   })

--- a/src/test/gamemaster-roster.test.ts
+++ b/src/test/gamemaster-roster.test.ts
@@ -1,6 +1,6 @@
 // @vitest-pool vmForks
 import { describe, it, expect } from 'vitest'
-import type { Game, Player, Team } from '@/db'
+import type { Player, Team } from '@/db'
 import {
   setPlayerAway,
   assignPlayerTeam,
@@ -9,11 +9,6 @@ import {
 } from '@/pages/admin/gamemaster-utils'
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
-
-const BASE_GAME: Pick<Game, 'maxTeams' | 'maxPerTeam'> = {
-  maxTeams: 0,
-  maxPerTeam: 0,
-}
 
 function makePlayer(overrides: Partial<Player> = {}): Player {
   return {
@@ -165,20 +160,14 @@ describe('canAssignToTeam', () => {
 
   it('returns false when team is at cap', () => {
     const team = makeTeam({ id: 't1' })
-    const players = [
-      makePlayer({ id: 'p1', teamId: 't1' }),
-      makePlayer({ id: 'p2', teamId: 't1' }),
-    ]
+    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p3')).toBe(false)
   })
 
   it('does not double-count player already on the team', () => {
     // p1 is already on t1 — moving p1 from t1 to t1 should not count twice
     const team = makeTeam({ id: 't1' })
-    const players = [
-      makePlayer({ id: 'p1', teamId: 't1' }),
-      makePlayer({ id: 'p2', teamId: 't1' }),
-    ]
+    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
     // cap=2, p1 already on t1 — reassigning p1 should be allowed
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p1')).toBe(true)
   })

--- a/src/test/gamemaster-roster.test.ts
+++ b/src/test/gamemaster-roster.test.ts
@@ -1,0 +1,199 @@
+// @vitest-pool vmForks
+import { describe, it, expect } from 'vitest'
+import type { Game, Player, Team } from '@/db'
+import {
+  setPlayerAway,
+  assignPlayerTeam,
+  canCreateTeam,
+  canAssignToTeam,
+} from '@/pages/admin/gamemaster-utils'
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const BASE_GAME: Pick<Game, 'maxTeams' | 'maxPerTeam'> = {
+  maxTeams: 0,
+  maxPerTeam: 0,
+}
+
+function makePlayer(overrides: Partial<Player> = {}): Player {
+  return {
+    id: 'p1',
+    gameId: 'g1',
+    name: 'Alice',
+    teamId: null,
+    score: 0,
+    isAway: false,
+    deviceId: 'dev-1',
+    joinedAt: 1000,
+    ...overrides,
+  }
+}
+
+function makeTeam(overrides: Partial<Team> = {}): Team {
+  return {
+    id: 't1',
+    gameId: 'g1',
+    name: 'Red Team',
+    color: '#e74c3c',
+    score: 0,
+    ...overrides,
+  }
+}
+
+// ── setPlayerAway ─────────────────────────────────────────────────────────────
+
+describe('setPlayerAway', () => {
+  it('marks the player as away when away=true', () => {
+    const players = [makePlayer({ id: 'p1', isAway: false })]
+    const result = setPlayerAway(players, 'p1', true)
+    expect(result[0].isAway).toBe(true)
+  })
+
+  it('marks the player as online when away=false', () => {
+    const players = [makePlayer({ id: 'p1', isAway: true })]
+    const result = setPlayerAway(players, 'p1', false)
+    expect(result[0].isAway).toBe(false)
+  })
+
+  it('leaves other players unchanged', () => {
+    const players = [makePlayer({ id: 'p1' }), makePlayer({ id: 'p2' })]
+    const result = setPlayerAway(players, 'p1', true)
+    expect(result.find(p => p.id === 'p2')?.isAway).toBe(false)
+  })
+
+  it('is a no-op for an unknown playerId', () => {
+    const players = [makePlayer({ id: 'p1' })]
+    const result = setPlayerAway(players, 'unknown', true)
+    expect(result[0].isAway).toBe(false)
+  })
+
+  it('does not mutate the original array', () => {
+    const players = [makePlayer({ id: 'p1' })]
+    setPlayerAway(players, 'p1', true)
+    expect(players[0].isAway).toBe(false)
+  })
+
+  it('handles empty list', () => {
+    expect(setPlayerAway([], 'p1', true)).toHaveLength(0)
+  })
+})
+
+// ── assignPlayerTeam ──────────────────────────────────────────────────────────
+
+describe('assignPlayerTeam', () => {
+  it('assigns the player to a team', () => {
+    const players = [makePlayer({ id: 'p1', teamId: null })]
+    const result = assignPlayerTeam(players, 'p1', 't1')
+    expect(result[0].teamId).toBe('t1')
+  })
+
+  it('clears team assignment when teamId is null', () => {
+    const players = [makePlayer({ id: 'p1', teamId: 't1' })]
+    const result = assignPlayerTeam(players, 'p1', null)
+    expect(result[0].teamId).toBeNull()
+  })
+
+  it('changes team when player is already on a different team', () => {
+    const players = [makePlayer({ id: 'p1', teamId: 't1' })]
+    const result = assignPlayerTeam(players, 'p1', 't2')
+    expect(result[0].teamId).toBe('t2')
+  })
+
+  it('leaves other players unchanged', () => {
+    const players = [makePlayer({ id: 'p1' }), makePlayer({ id: 'p2', teamId: 't1' })]
+    const result = assignPlayerTeam(players, 'p1', 't2')
+    expect(result.find(p => p.id === 'p2')?.teamId).toBe('t1')
+  })
+
+  it('is a no-op for unknown playerId', () => {
+    const players = [makePlayer({ id: 'p1', teamId: null })]
+    const result = assignPlayerTeam(players, 'unknown', 't1')
+    expect(result[0].teamId).toBeNull()
+  })
+
+  it('does not mutate the original array', () => {
+    const players = [makePlayer({ id: 'p1', teamId: null })]
+    assignPlayerTeam(players, 'p1', 't1')
+    expect(players[0].teamId).toBeNull()
+  })
+})
+
+// ── canCreateTeam ─────────────────────────────────────────────────────────────
+
+describe('canCreateTeam', () => {
+  it('always returns true when maxTeams is 0 (unlimited)', () => {
+    expect(canCreateTeam({ maxTeams: 0 }, 0)).toBe(true)
+    expect(canCreateTeam({ maxTeams: 0 }, 100)).toBe(true)
+  })
+
+  it('returns true when below the cap', () => {
+    expect(canCreateTeam({ maxTeams: 4 }, 3)).toBe(true)
+    expect(canCreateTeam({ maxTeams: 4 }, 0)).toBe(true)
+  })
+
+  it('returns false when at the cap', () => {
+    expect(canCreateTeam({ maxTeams: 4 }, 4)).toBe(false)
+  })
+
+  it('returns false when above the cap', () => {
+    expect(canCreateTeam({ maxTeams: 2 }, 5)).toBe(false)
+  })
+
+  it('returns true for cap of 1 with 0 teams', () => {
+    expect(canCreateTeam({ maxTeams: 1 }, 0)).toBe(true)
+  })
+
+  it('returns false for cap of 1 with 1 team', () => {
+    expect(canCreateTeam({ maxTeams: 1 }, 1)).toBe(false)
+  })
+})
+
+// ── canAssignToTeam ───────────────────────────────────────────────────────────
+
+describe('canAssignToTeam', () => {
+  it('always returns true when maxPerTeam is 0 (unlimited)', () => {
+    const team = makeTeam({ id: 't1' })
+    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
+    expect(canAssignToTeam({ maxPerTeam: 0 }, team, players, 'p3')).toBe(true)
+  })
+
+  it('returns true when team has fewer members than cap', () => {
+    const team = makeTeam({ id: 't1' })
+    const players = [makePlayer({ id: 'p1', teamId: 't1' })]
+    expect(canAssignToTeam({ maxPerTeam: 3 }, team, players, 'p2')).toBe(true)
+  })
+
+  it('returns false when team is at cap', () => {
+    const team = makeTeam({ id: 't1' })
+    const players = [
+      makePlayer({ id: 'p1', teamId: 't1' }),
+      makePlayer({ id: 'p2', teamId: 't1' }),
+    ]
+    expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p3')).toBe(false)
+  })
+
+  it('does not double-count player already on the team', () => {
+    // p1 is already on t1 — moving p1 from t1 to t1 should not count twice
+    const team = makeTeam({ id: 't1' })
+    const players = [
+      makePlayer({ id: 'p1', teamId: 't1' }),
+      makePlayer({ id: 'p2', teamId: 't1' }),
+    ]
+    // cap=2, p1 already on t1 — reassigning p1 should be allowed
+    expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p1')).toBe(true)
+  })
+
+  it('returns true for an empty team with any cap > 0', () => {
+    const team = makeTeam({ id: 't1' })
+    expect(canAssignToTeam({ maxPerTeam: 1 }, team, [], 'p1')).toBe(true)
+  })
+
+  it('counts only members of the target team, not all players', () => {
+    const team = makeTeam({ id: 't1' })
+    const players = [
+      makePlayer({ id: 'p1', teamId: 't2' }), // on a different team
+      makePlayer({ id: 'p2', teamId: 't2' }),
+    ]
+    expect(canAssignToTeam({ maxPerTeam: 1 }, team, players, 'p3')).toBe(true)
+  })
+})

--- a/src/test/gamemaster-roster.test.ts
+++ b/src/test/gamemaster-roster.test.ts
@@ -27,6 +27,7 @@ function makePlayer(overrides: Partial<Player> = {}): Player {
 function makeTeam(overrides: Partial<Team> = {}): Team {
   return {
     id: 't1',
+    icon: 'star',
     gameId: 'g1',
     name: 'Red Team',
     color: '#e74c3c',
@@ -160,20 +161,14 @@ describe('canAssignToTeam', () => {
 
   it('returns false when team is at cap', () => {
     const team = makeTeam({ id: 't1' })
-    const players = [
-      makePlayer({ id: 'p1', teamId: 't1' }),
-      makePlayer({ id: 'p2', teamId: 't1' }),
-    ]
+    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p3')).toBe(false)
   })
 
   it('does not double-count player already on the team', () => {
     // p1 is already on t1 — moving p1 from t1 to t1 should not count twice
     const team = makeTeam({ id: 't1' })
-    const players = [
-      makePlayer({ id: 'p1', teamId: 't1' }),
-      makePlayer({ id: 'p2', teamId: 't1' }),
-    ]
+    const players = [makePlayer({ id: 'p1', teamId: 't1' }), makePlayer({ id: 'p2', teamId: 't1' })]
     // cap=2, p1 already on t1 — reassigning p1 should be allowed
     expect(canAssignToTeam({ maxPerTeam: 2 }, team, players, 'p1')).toBe(true)
   })

--- a/src/test/scoreboard.test.ts
+++ b/src/test/scoreboard.test.ts
@@ -71,6 +71,7 @@ function makeTeam(overrides: Partial<Team> = {}): Team {
   return {
     id: 't1',
     gameId: 'g1',
+    icon: 'shield',
     name: 'Red Team',
     color: '#c0392b',
     score: 0,


### PR DESCRIPTION
- Handle FOCUS_CHANGE PlayerEvent -> persists player.isAway to DB
- Add RosterPanel: player name, team badge, score, online/away dot, kick
- Add TeamManagerPanel: create team with colour picker, assign player to
  team via dropdown, disable full teams in selector
- Add setPlayerAway and assignPlayerTeam pure utils for state updates
- Add canCreateTeam / canAssignToTeam pure helpers enforcing maxTeams
  and maxPerTeam caps (0 = unlimited)
- Wire both panels into the GameMaster lobby replacing the old plain list
- Broadcast GAME_STATE after kick and player team-assignment changes
- Load session teams alongside players on GameMaster mount

Closes #13, closes #134