### PR TITLE
feat(ui): in-game progress indicator with round pills and question circles

### DIFF
--- a/src/components/NavHeader.tsx
+++ b/src/components/NavHeader.tsx
@@ -1,22 +1,33 @@
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Icon } from '@/components/ui'
-import type { NavPosition } from '@/pages/admin/gamemaster-utils'
+import type { NavEntry, NavPosition } from '@/pages/admin/gamemaster-utils'
 
 interface NavHeaderProps {
   pos: NavPosition
-  totalQ: number
+  seq: NavEntry[]
   onPrev: () => void
   onNext: () => void
 }
 
 /**
- * Navigation header shown during an active game:
- * - Round name + question position label
- * - Progress bar across all questions
- * - Prev / Next buttons (disabled at boundaries)
+ * Navigation header shown during an active game.
+ *
+ * Progress track:
+ *   - One pill per round
+ *   - Current round: expanded, shows one circle per question
+ *     - done: filled --color-positive
+ *     - active: larger, filled --color-accent
+ *     - todo: hollow border
+ *   - Other rounds: collapsed to a fixed-width pill
+ *     - done: --color-positive (dimmed)
+ *     - todo: --color-border
+ *
+ * Uses semantic CSS variables (--color-accent, --color-positive) so the
+ * indicator respects any future theme without component changes.
  */
-export function NavHeader({ pos, totalQ, onPrev, onNext }: NavHeaderProps) {
-  const progress = totalQ > 1 ? pos.flatIndex / (totalQ - 1) : 1
+export function NavHeader({ pos, seq, onPrev, onNext }: NavHeaderProps) {
+  // Build per-round summaries from the flat sequence
+  const rounds = buildRoundSummaries(seq)
 
   return (
     <div
@@ -35,32 +46,37 @@ export function NavHeader({ pos, totalQ, onPrev, onNext }: NavHeaderProps) {
       </button>
 
       {/* Centre: label + progress */}
-      <div className="flex-1 flex flex-col gap-1.5 min-w-0">
+      <div className="flex-1 flex flex-col gap-2 min-w-0">
+        {/* Label row */}
         <div className="flex items-baseline justify-between gap-2">
           <span className="text-sm font-semibold truncate" style={{ color: 'var(--color-ink)' }}>
             {pos.roundIdx >= 0 ? `Round ${pos.roundIdx + 1}` : ''}
           </span>
           <span className="text-xs shrink-0 mono" style={{ color: 'var(--color-muted)' }}>
-            Q {pos.flatIndex + 1} / {totalQ}
+            Q {pos.flatIndex + 1} / {seq.length}
           </span>
         </div>
 
-        {/* Progress bar */}
+        {/* Progress track */}
         <div
-          className="h-1.5 rounded-full overflow-hidden"
-          style={{ background: 'var(--color-border)' }}
+          className="flex items-center gap-1"
           role="progressbar"
           aria-valuenow={pos.flatIndex + 1}
           aria-valuemin={1}
-          aria-valuemax={totalQ}
+          aria-valuemax={seq.length}
+          aria-label={`Question ${pos.flatIndex + 1} of ${seq.length}`}
         >
-          <div
-            className="h-full rounded-full transition-all duration-300"
-            style={{
-              width: `${progress * 100}%`,
-              background: 'var(--color-gold)',
-            }}
-          />
+          {rounds.map(round => {
+            const isCurrent = round.roundIdx === pos.roundIdx
+
+            if (isCurrent) {
+              return (
+                <ActiveRoundPill key={round.roundId} round={round} questionIdx={pos.questionIdx} />
+              )
+            }
+
+            return <CollapsedRoundPill key={round.roundId} done={round.roundIdx < pos.roundIdx} />
+          })}
         </div>
       </div>
 
@@ -76,4 +92,96 @@ export function NavHeader({ pos, totalQ, onPrev, onNext }: NavHeaderProps) {
       </button>
     </div>
   )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RoundSummary {
+  roundId: string
+  roundIdx: number
+  questionCount: number
+}
+
+function CollapsedRoundPill({ done }: { done: boolean }) {
+  return (
+    <div
+      className="h-2 rounded-full shrink-0 transition-colors duration-200"
+      style={{
+        width: 20,
+        background: done ? 'var(--color-positive)' : 'var(--color-border)',
+        opacity: done ? 0.45 : 0.7,
+      }}
+    />
+  )
+}
+
+function ActiveRoundPill({ round, questionIdx }: { round: RoundSummary; questionIdx: number }) {
+  return (
+    <div
+      className="flex items-center gap-1 rounded-full px-2 shrink-0"
+      style={{
+        paddingTop: 4,
+        paddingBottom: 4,
+        background: 'var(--color-border)',
+        opacity: 1,
+      }}
+    >
+      {Array.from({ length: round.questionCount }, (_, i) => {
+        const done = i < questionIdx
+        const active = i === questionIdx
+
+        return (
+          <div
+            key={i}
+            className="rounded-full transition-all duration-200"
+            style={
+              active
+                ? {
+                    width: 10,
+                    height: 10,
+                    background: 'var(--color-accent)',
+                    flexShrink: 0,
+                  }
+                : done
+                  ? {
+                      width: 8,
+                      height: 8,
+                      background: 'var(--color-positive)',
+                      flexShrink: 0,
+                    }
+                  : {
+                      width: 8,
+                      height: 8,
+                      background: 'transparent',
+                      border: '1.5px solid var(--color-muted)',
+                      flexShrink: 0,
+                      opacity: 0.5,
+                    }
+            }
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildRoundSummaries(seq: NavEntry[]): RoundSummary[] {
+  const seen = new Map<string, RoundSummary>()
+  for (const entry of seq) {
+    if (!seen.has(entry.roundId)) {
+      seen.set(entry.roundId, {
+        roundId: entry.roundId,
+        roundIdx: entry.roundIdx,
+        questionCount: 0,
+      })
+    }
+    seen.get(entry.roundId)!.questionCount++
+  }
+  return [...seen.values()].sort((a, b) => a.roundIdx - b.roundIdx)
 }

--- a/src/components/ui/Steps.tsx
+++ b/src/components/ui/Steps.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+
+export interface StepConfig {
+  label: string
+}
+
+interface StepsProps {
+  steps: StepConfig[]
+  /** 0-based index of the active step */
+  current: number
+}
+
+/**
+ * Compact dot + connector step indicator.
+ *
+ * States:
+ *   completed  — filled dot (bg-ink)
+ *   active     — filled dot with ring
+ *   upcoming   — hollow dot (border-2 border-border)
+ *
+ * The current step label is shown centred below the track.
+ */
+export function Steps({ steps, current }: StepsProps) {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* Track */}
+      <div className="flex items-center">
+        {steps.map((step, i) => {
+          const completed = i < current
+          const active = i === current
+          const last = i === steps.length - 1
+
+          return (
+            <React.Fragment key={step.label}>
+              <div
+                role="img"
+                aria-label={
+                  active
+                    ? `${step.label} (current)`
+                    : completed
+                      ? `${step.label} (completed)`
+                      : step.label
+                }
+                className={[
+                  'h-2.5 w-2.5 rounded-full transition-colors duration-200',
+                  completed
+                    ? 'bg-ink'
+                    : active
+                      ? 'bg-ink ring-2 ring-ink ring-offset-2 ring-offset-cream'
+                      : 'border-2 border-border bg-cream',
+                ].join(' ')}
+              />
+              {!last && (
+                <div
+                  className={[
+                    'h-px w-8 transition-colors duration-200',
+                    completed ? 'bg-ink' : 'bg-border',
+                  ].join(' ')}
+                />
+              )}
+            </React.Fragment>
+          )
+        })}
+      </div>
+
+      {/* Active step label */}
+      <p className="text-xs transition-all duration-200" style={{ color: 'var(--color-muted)' }}>
+        {steps[current]?.label}
+      </p>
+    </div>
+  )
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -4,6 +4,8 @@ import { Icon } from './Icon'
 import type { TransportStatus, TransportType } from '@/transport/types'
 
 export { Icon } from './Icon'
+export { Steps } from './Steps'
+export type { StepConfig } from './Steps'
 
 // ── Button ────────────────────────────────────────────────────────────────────
 

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,12 @@ html[data-theme='light'] {
   --color-muted: #7a6f5e;
   --color-border: #d4c9b5;
   --color-surface: #ede8dc;
+  /* semantic aliases -- new components use these; existing components
+     will be migrated in a follow-up refactor */
+  --color-accent: var(--color-gold);
+  --color-accent-subtle: var(--color-gold-light);
+  --color-positive: var(--color-green);
+  --color-negative: var(--color-red);
 }
 
 /* Dark theme */
@@ -26,6 +32,10 @@ html[data-theme='dark'] {
   --color-muted: #8a8070;
   --color-border: #2e2a24;
   --color-surface: #211e1a;
+  --color-accent: var(--color-gold);
+  --color-accent-subtle: var(--color-gold-light);
+  --color-positive: var(--color-green);
+  --color-negative: var(--color-red);
 }
 
 /* System preference fallback (when data-theme="system" or unset) */
@@ -40,6 +50,10 @@ html[data-theme='dark'] {
     --color-muted: #8a8070;
     --color-border: #2e2a24;
     --color-surface: #211e1a;
+    --color-accent: var(--color-gold);
+    --color-accent-subtle: var(--color-gold-light);
+    --color-positive: var(--color-green);
+    --color-negative: var(--color-red);
   }
 }
 

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -405,7 +405,7 @@ function ActiveGame({ game, players, onGameChange, lifecycle }: ActiveGameProps)
         lifecycle={lifecycle}
       />
 
-      <NavHeader pos={pos} totalQ={seq.length} onPrev={goPrev} onNext={goNext} />
+      <NavHeader pos={pos} seq={seq} onPrev={goPrev} onNext={goNext} />
 
       <div className="flex-1 overflow-y-auto px-8 py-6">
         <div className="max-w-3xl mx-auto flex flex-col gap-6">
@@ -594,38 +594,32 @@ export default function GameMaster() {
   }, [handleEvent])
 
   // Kick player — mark as away in DB + state, broadcast updated game state
-  const handleKick = useCallback(
-    async (playerId: string) => {
-      const g = gameRef.current
-      if (!g) return
-      await db.players.update(playerId, { isAway: true })
-      setPlayers(prev => {
-        const updated = markPlayerAway(prev, playerId)
-        transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
-        return updated
-      })
-    },
-    []
-  )
+  const handleKick = useCallback(async (playerId: string) => {
+    const g = gameRef.current
+    if (!g) return
+    await db.players.update(playerId, { isAway: true })
+    setPlayers(prev => {
+      const updated = markPlayerAway(prev, playerId)
+      transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
+      return updated
+    })
+  }, [])
 
   // Create a session team, persist to DB, broadcast GAME_STATE
-  const handleCreateTeam = useCallback(
-    async (name: string, color: string, icon: string) => {
-      const g = gameRef.current
-      if (!g) return
-      const team: Team = {
-        id: crypto.randomUUID(),
-        gameId: g.id,
-        name,
-        color,
-        icon,
-        score: 0,
-      }
-      await db.teams.add(team)
-      setTeams(prev => [...prev, team])
-    },
-    []
-  )
+  const handleCreateTeam = useCallback(async (name: string, color: string, icon: string) => {
+    const g = gameRef.current
+    if (!g) return
+    const team: Team = {
+      id: crypto.randomUUID(),
+      gameId: g.id,
+      name,
+      color,
+      icon,
+      score: 0,
+    }
+    await db.teams.add(team)
+    setTeams(prev => [...prev, team])
+  }, [])
 
   // Import all active managed teams (and their players) into the session
   const handleImportFromManaged = useCallback(async () => {
@@ -638,7 +632,9 @@ export default function GameMaster() {
     ])
 
     // Upsert teams — skip any already in the session (by id)
-    const existingTeamIds = new Set((await db.teams.where('gameId').equals(g.id).toArray()).map(t => t.id))
+    const existingTeamIds = new Set(
+      (await db.teams.where('gameId').equals(g.id).toArray()).map(t => t.id)
+    )
     const newTeams: Team[] = managedTeams
       .filter(mt => !existingTeamIds.has(mt.id))
       .map(mt => ({
@@ -652,7 +648,9 @@ export default function GameMaster() {
     if (newTeams.length > 0) await db.teams.bulkAdd(newTeams)
 
     // Upsert players — skip any already in the session (by id)
-    const existingPlayerIds = new Set((await db.players.where('gameId').equals(g.id).toArray()).map(p => p.id))
+    const existingPlayerIds = new Set(
+      (await db.players.where('gameId').equals(g.id).toArray()).map(p => p.id)
+    )
     const now = Date.now()
     const newPlayers: import('@/db').Player[] = managedPlayers
       .filter(mp => !existingPlayerIds.has(mp.id))
@@ -679,19 +677,16 @@ export default function GameMaster() {
   }, [])
 
   // Assign a player to a team (or clear), persist to DB, broadcast GAME_STATE
-  const handleAssignPlayer = useCallback(
-    async (playerId: string, teamId: string | null) => {
-      const g = gameRef.current
-      if (!g) return
-      await db.players.update(playerId, { teamId })
-      setPlayers(prev => {
-        const updated = assignPlayerTeam(prev, playerId, teamId)
-        transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
-        return updated
-      })
-    },
-    []
-  )
+  const handleAssignPlayer = useCallback(async (playerId: string, teamId: string | null) => {
+    const g = gameRef.current
+    if (!g) return
+    await db.players.update(playerId, { teamId })
+    setPlayers(prev => {
+      const updated = assignPlayerTeam(prev, playerId, teamId)
+      transportManager.send({ type: 'GAME_STATE', state: serialiseGameState(g, updated) })
+      return updated
+    })
+  }, [])
 
   // Start the game
   async function handleStart() {
@@ -759,12 +754,7 @@ export default function GameMaster() {
   // Active / paused / ended — navigation view
   return (
     <AdminLayout>
-      <ActiveGame
-        game={game}
-        players={players}
-        onGameChange={setGame}
-        lifecycle={lifecycle}
-      />
+      <ActiveGame game={game} players={players} onGameChange={setGame} lifecycle={lifecycle} />
     </AdminLayout>
   )
 }

--- a/src/test/ui.test.tsx
+++ b/src/test/ui.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { NavHeader } from '@/components/NavHeader'
+import type { NavEntry, NavPosition } from '@/pages/admin/gamemaster-utils'
 import {
   Button,
   Badge,
@@ -10,6 +12,7 @@ import {
   Modal,
   Empty,
   TransportPill,
+  Steps,
 } from '@/components/ui'
 
 // ── Button ────────────────────────────────────────────────────────────────────
@@ -274,5 +277,154 @@ describe('TransportPill', () => {
   it('shows Offline when idle', () => {
     render(<TransportPill status="idle" type={null} />)
     expect(screen.getByText('Offline')).toBeInTheDocument()
+  })
+})
+
+// ── Steps ─────────────────────────────────────────────────────────────────────
+
+const STEPS = [
+  { label: 'Basic settings' },
+  { label: 'Select rounds' },
+  { label: 'Review & create' },
+]
+
+describe('Steps', () => {
+  it('renders one dot per step', () => {
+    const { container } = render(<Steps steps={STEPS} current={0} />)
+    const dots = container.querySelectorAll('[role="img"]')
+    expect(dots).toHaveLength(3)
+  })
+
+  it('shows the active step label', () => {
+    render(<Steps steps={STEPS} current={1} />)
+    expect(screen.getByText('Select rounds')).toBeInTheDocument()
+  })
+
+  it('labels the active step as current', () => {
+    render(<Steps steps={STEPS} current={0} />)
+    expect(screen.getByRole('img', { name: 'Basic settings (current)' })).toBeInTheDocument()
+  })
+
+  it('labels completed steps accordingly', () => {
+    render(<Steps steps={STEPS} current={2} />)
+    expect(screen.getByRole('img', { name: 'Basic settings (completed)' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Select rounds (completed)' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Review & create (current)' })).toBeInTheDocument()
+  })
+
+  it('labels upcoming steps with no suffix', () => {
+    render(<Steps steps={STEPS} current={0} />)
+    expect(screen.getByRole('img', { name: 'Select rounds' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Review & create' })).toBeInTheDocument()
+  })
+
+  it('updates label when current changes', () => {
+    const { rerender } = render(<Steps steps={STEPS} current={0} />)
+    expect(screen.getByText('Basic settings')).toBeInTheDocument()
+    rerender(<Steps steps={STEPS} current={2} />)
+    expect(screen.getByText('Review & create')).toBeInTheDocument()
+  })
+})
+
+// ── NavHeader ─────────────────────────────────────────────────────────────────
+
+function makeSeq(roundQuestions: number[]): NavEntry[] {
+  const entries: NavEntry[] = []
+  let flat = 0
+  roundQuestions.forEach((count, roundIdx) => {
+    const roundId = `round-${roundIdx}`
+    for (let q = 0; q < count; q++) {
+      entries.push({
+        flatIndex: flat++,
+        roundIdx,
+        roundId,
+        roundName: `Round ${roundIdx + 1}`,
+        questionId: `q-${roundIdx}-${q}`,
+        gameQuestionId: `gq-${roundIdx}-${q}`,
+        questionStatus: 'pending',
+      })
+    }
+  })
+  return entries
+}
+
+function makePos(seq: NavEntry[], flatIndex: number): NavPosition {
+  const entry = seq[flatIndex]
+  const inRound = seq.filter(e => e.roundId === entry.roundId)
+  const questionIdx = inRound.findIndex(e => e.flatIndex === flatIndex)
+  return {
+    flatIndex,
+    roundIdx: entry.roundIdx,
+    questionIdx,
+    roundQuestions: inRound.length,
+    isFirst: flatIndex === 0,
+    isLast: flatIndex === seq.length - 1,
+    isRoundBoundary: false,
+  }
+}
+
+describe('NavHeader', () => {
+  it('renders prev and next buttons', () => {
+    const seq = makeSeq([3, 3])
+    const pos = makePos(seq, 1)
+    render(<NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />)
+    expect(screen.getByLabelText('Previous question')).toBeInTheDocument()
+    expect(screen.getByLabelText('Next question')).toBeInTheDocument()
+  })
+
+  it('disables prev on first question', () => {
+    const seq = makeSeq([3, 3])
+    const pos = makePos(seq, 0)
+    render(<NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />)
+    expect(screen.getByLabelText('Previous question')).toBeDisabled()
+    expect(screen.getByLabelText('Next question')).not.toBeDisabled()
+  })
+
+  it('disables next on last question', () => {
+    const seq = makeSeq([3, 3])
+    const pos = makePos(seq, 5)
+    render(<NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />)
+    expect(screen.getByLabelText('Next question')).toBeDisabled()
+    expect(screen.getByLabelText('Previous question')).not.toBeDisabled()
+  })
+
+  it('shows correct round and question label', () => {
+    const seq = makeSeq([4, 3])
+    const pos = makePos(seq, 5)
+    render(<NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />)
+    expect(screen.getByText('Round 2')).toBeInTheDocument()
+    expect(screen.getByText('Q 6 / 7')).toBeInTheDocument()
+  })
+
+  it('fires onPrev and onNext when clicked', () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    const seq = makeSeq([3, 3])
+    const pos = makePos(seq, 2)
+    render(<NavHeader pos={pos} seq={seq} onPrev={onPrev} onNext={onNext} />)
+    fireEvent.click(screen.getByLabelText('Previous question'))
+    fireEvent.click(screen.getByLabelText('Next question'))
+    expect(onPrev).toHaveBeenCalledOnce()
+    expect(onNext).toHaveBeenCalledOnce()
+  })
+
+  it('renders one pill per round', () => {
+    const seq = makeSeq([3, 4, 2])
+    const pos = makePos(seq, 0)
+    const { container } = render(
+      <NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />
+    )
+    const track = container.querySelector('[role="progressbar"]')!
+    // three direct children of the track = three round pills
+    expect(track.children).toHaveLength(3)
+  })
+
+  it('sets correct aria attributes on the progress track', () => {
+    const seq = makeSeq([3, 3])
+    const pos = makePos(seq, 3)
+    render(<NavHeader pos={pos} seq={seq} onPrev={vi.fn()} onNext={vi.fn()} />)
+    const bar = screen.getByRole('progressbar')
+    expect(bar).toHaveAttribute('aria-valuenow', '4')
+    expect(bar).toHaveAttribute('aria-valuemax', '6')
   })
 })


### PR DESCRIPTION
Replace the flat progress bar in NavHeader with a pill-per-round track. Current round expands to show one circle per question (done/active/todo). Other rounds collapse to a fixed-width pill (positive/dimmed or border).

Introduces --color-accent and --color-positive semantic CSS variable aliases in index.css. NavHeader is the first component to use them; existing components migrate in a follow-up refactor.

Prop change: NavHeader no longer accepts totalQ -- pass seq instead. buildRoundSummaries() derives per-round question counts from the flat sequence with no extra DB queries.