### PR TITLE
refactor(ui): replace full-screen timer overlay with toast system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { HashRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { lazy, Suspense, useEffect } from 'react'
 import { seedDefaults } from '@/db'
+import { ToastProvider } from '@/components/ui'
 
 // Pages — Admin (lazy-loaded per route)
 const Dashboard = lazy(() => import('@/pages/admin/Dashboard'))
@@ -29,25 +30,27 @@ export default function App() {
   }, [])
 
   return (
-    <HashRouter>
-      <Suspense fallback={<Loading />}>
-        <Routes>
-          <Route path="/" element={<Navigate to="/admin" replace />} />
-          <Route path="/admin" element={<Dashboard />} />
-          <Route path="/admin/questions" element={<Questions />} />
-          <Route path="/admin/games" element={<Games />} />
-          <Route path="/admin/game/:id" element={<GameMaster />} />
-          <Route path="/admin/layouts/:gameId" element={<Layouts />} />
-          <Route path="/admin/players-teams" element={<PlayersTeams />} />
-          <Route path="/admin/notes" element={<Notes />} />
-          <Route path="/admin/notes/:id" element={<NoteDetail />} />
-          <Route path="/admin/settings" element={<Settings />} />
-          <Route path="/join" element={<Join />} />
-          <Route path="/join/:roomId" element={<Join />} />
-          <Route path="/play/:roomId" element={<Play />} />
-          <Route path="*" element={<Navigate to="/admin" replace />} />
-        </Routes>
-      </Suspense>
-    </HashRouter>
+    <ToastProvider>
+      <HashRouter>
+        <Suspense fallback={<Loading />}>
+          <Routes>
+            <Route path="/" element={<Navigate to="/admin" replace />} />
+            <Route path="/admin" element={<Dashboard />} />
+            <Route path="/admin/questions" element={<Questions />} />
+            <Route path="/admin/games" element={<Games />} />
+            <Route path="/admin/game/:id" element={<GameMaster />} />
+            <Route path="/admin/layouts/:gameId" element={<Layouts />} />
+            <Route path="/admin/players-teams" element={<PlayersTeams />} />
+            <Route path="/admin/notes" element={<Notes />} />
+            <Route path="/admin/notes/:id" element={<NoteDetail />} />
+            <Route path="/admin/settings" element={<Settings />} />
+            <Route path="/join" element={<Join />} />
+            <Route path="/join/:roomId" element={<Join />} />
+            <Route path="/play/:roomId" element={<Play />} />
+            <Route path="*" element={<Navigate to="/admin" replace />} />
+          </Routes>
+        </Suspense>
+      </HashRouter>
+    </ToastProvider>
   )
 }

--- a/src/components/timer/TimerExpiredOverlay.tsx
+++ b/src/components/timer/TimerExpiredOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { AlarmClock } from 'lucide-react'
 import { Icon } from '@/components/ui'
 
@@ -10,7 +10,8 @@ interface TimerExpiredOverlayProps {
 }
 
 /**
- * Fullscreen overlay shown when a timer hits zero.
+ * Full-screen overlay shown on the **player** screen when a timer hits zero.
+ * The host-side equivalent was replaced by a toast notification (#173).
  * Auto-dismisses after autoDismissMs or on click/keypress.
  */
 export function TimerExpiredOverlay({
@@ -19,6 +20,8 @@ export function TimerExpiredOverlay({
   autoDismissMs = 5000,
 }: TimerExpiredOverlayProps) {
   const [progress, setProgress] = useState(1)
+
+  const handleDismiss = useCallback(() => onDismiss(), [onDismiss])
 
   useEffect(() => {
     const start = performance.now()
@@ -29,7 +32,7 @@ export function TimerExpiredOverlay({
       const p = Math.max(0, 1 - elapsed / autoDismissMs)
       setProgress(p)
       if (p <= 0) {
-        onDismiss()
+        handleDismiss()
         return
       }
       rafId = requestAnimationFrame(tick)
@@ -37,15 +40,15 @@ export function TimerExpiredOverlay({
 
     rafId = requestAnimationFrame(tick)
     return () => cancelAnimationFrame(rafId)
-  }, [autoDismissMs, onDismiss])
+  }, [autoDismissMs, handleDismiss])
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') onDismiss()
+      if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') handleDismiss()
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [onDismiss])
+  }, [handleDismiss])
 
   const circumference = 2 * Math.PI * 20
 
@@ -53,9 +56,9 @@ export function TimerExpiredOverlay({
     <div
       className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 cursor-pointer"
       style={{ background: 'rgba(0,0,0,0.82)' }}
-      onClick={onDismiss}
+      onClick={handleDismiss}
     >
-      {/* Pulsing ring */}
+      {/* Countdown ring */}
       <div className="relative flex items-center justify-center">
         <svg width="120" height="120" viewBox="0 0 48 48">
           <circle

--- a/src/components/timer/TimerPanel.tsx
+++ b/src/components/timer/TimerPanel.tsx
@@ -1,10 +1,9 @@
 import { useState, useCallback } from 'react'
 import { Plus, PauseCircle, PlayCircle, RotateCcw, Trash2 } from 'lucide-react'
-import { Button, Icon } from '@/components/ui'
+import { Button, Icon, useToast, timerExpiredToast } from '@/components/ui'
 import { TimerCard } from './TimerCard'
 import { CreateTimerModal } from './CreateTimerModal'
 import { EditTimerModal } from './EditTimerModal'
-import { TimerExpiredOverlay } from './TimerExpiredOverlay'
 import { useTimerExpiry } from '@/hooks/useTimer'
 import type { UseTimerListResult, ExpiryEvent } from '@/hooks/useTimer'
 import type { Timer } from '@/db'
@@ -25,7 +24,7 @@ interface TimerPanelProps {
 export function TimerPanel({ gameId, hook }: TimerPanelProps) {
   const [showCreate, setShowCreate] = useState(false)
   const [editingTimer, setEditingTimer] = useState<Timer | null>(null)
-  const [expiredEvent, setExpiredEvent] = useState<ExpiryEvent | null>(null)
+  const { addToast } = useToast()
 
   const {
     timers,
@@ -49,11 +48,14 @@ export function TimerPanel({ gameId, hook }: TimerPanelProps) {
 
   const handlePauseResumeAll = allPaused ? resumeAll : pauseAll
 
-  const handleExpire = useCallback((evt: ExpiryEvent) => {
-    if (evt.visualNotify === 'host' || evt.visualNotify === 'both') {
-      setExpiredEvent(evt)
-    }
-  }, [])
+  const handleExpire = useCallback(
+    (evt: ExpiryEvent) => {
+      if (evt.visualNotify === 'host' || evt.visualNotify === 'both') {
+        timerExpiredToast(addToast, evt.label)
+      }
+    },
+    [addToast]
+  )
 
   useTimerExpiry(timers, remaining, handleExpire)
 
@@ -65,10 +67,6 @@ export function TimerPanel({ gameId, hook }: TimerPanelProps) {
 
   return (
     <>
-      {expiredEvent && (
-        <TimerExpiredOverlay label={expiredEvent.label} onDismiss={() => setExpiredEvent(null)} />
-      )}
-
       {showCreate && (
         <CreateTimerModal onConfirm={handleCreate} onCancel={() => setShowCreate(false)} />
       )}

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { X, Info, AlertTriangle, AlertCircle } from 'lucide-react'
+import { Icon } from './Icon'
+import { ToastContext } from './toastContext'
+import type { Toast, ToastOptions, ToastVariant } from './toastContext'
+
+// Computed once at module load -- safe to use during render
+const PREFERS_REDUCED_MOTION =
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+// ── Provider ──────────────────────────────────────────────────────────────────
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id))
+  }, [])
+
+  const addToast = useCallback((message: string, options: ToastOptions = {}): string => {
+    const id = crypto.randomUUID()
+    const toast: Toast = {
+      id,
+      message,
+      variant: options.variant ?? 'info',
+      durationMs: options.durationMs ?? 5000,
+      icon: options.icon,
+    }
+    setToasts(prev => [...prev, toast])
+    return id
+  }, [])
+
+  return (
+    <ToastContext.Provider value={{ addToast, removeToast }}>
+      {children}
+      <ToastStack toasts={toasts} onRemove={removeToast} />
+    </ToastContext.Provider>
+  )
+}
+
+// ── Stack ─────────────────────────────────────────────────────────────────────
+
+function ToastStack({ toasts, onRemove }: { toasts: Toast[]; onRemove: (id: string) => void }) {
+  if (toasts.length === 0) return null
+
+  return (
+    <div
+      aria-live="polite"
+      aria-label="Notifications"
+      className="fixed top-4 right-4 z-50 flex flex-col gap-2 pointer-events-none"
+      style={{ maxWidth: '360px', width: 'calc(100vw - 2rem)' }}
+    >
+      {toasts.map(toast => (
+        <ToastItem key={toast.id} toast={toast} onRemove={onRemove} />
+      ))}
+    </div>
+  )
+}
+
+// ── Item ──────────────────────────────────────────────────────────────────────
+
+const VARIANT_STYLES: Record<ToastVariant, { border: string; iconColor: string }> = {
+  info: { border: 'var(--color-gold)', iconColor: 'var(--color-gold)' },
+  warning: { border: 'var(--color-amber, #f59e0b)', iconColor: 'var(--color-amber, #f59e0b)' },
+  error: { border: 'var(--color-red)', iconColor: 'var(--color-red)' },
+}
+
+const VARIANT_ICONS: Record<ToastVariant, LucideIcon> = {
+  info: Info,
+  warning: AlertTriangle,
+  error: AlertCircle,
+}
+
+function ToastItem({ toast, onRemove }: { toast: Toast; onRemove: (id: string) => void }) {
+  const [visible, setVisible] = useState(false)
+  const [leaving, setLeaving] = useState(false)
+  const reduced = PREFERS_REDUCED_MOTION
+
+  // One-frame delay so the initial hidden state paints before the enter transition
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    if (reduced) {
+      onRemove(toast.id)
+      return
+    }
+    setLeaving(true)
+    setTimeout(() => onRemove(toast.id), 200)
+  }, [onRemove, toast.id, reduced])
+
+  useEffect(() => {
+    if (toast.durationMs === 0) return
+    const timer = setTimeout(dismiss, toast.durationMs)
+    return () => clearTimeout(timer)
+  }, [toast.durationMs, dismiss])
+
+  const styles = VARIANT_STYLES[toast.variant]
+  const DefaultIcon = VARIANT_ICONS[toast.variant]
+  const opacity = reduced ? 1 : visible && !leaving ? 1 : 0
+  const translateY = reduced ? '0px' : visible && !leaving ? '0px' : '-8px'
+
+  return (
+    <div
+      role={toast.variant === 'error' ? 'alert' : 'status'}
+      aria-live={toast.variant === 'error' ? 'assertive' : 'polite'}
+      className="pointer-events-auto flex items-start gap-3 rounded-lg px-3 py-3 shadow-lg border"
+      style={{
+        background: 'var(--color-surface)',
+        borderColor: styles.border,
+        borderLeftWidth: '3px',
+        opacity,
+        transform: `translateY(${translateY})`,
+        transition: reduced ? 'none' : 'opacity 0.18s ease, transform 0.18s ease',
+        boxShadow: '0 4px 16px rgba(0,0,0,0.14)',
+      }}
+    >
+      <span className="mt-0.5 shrink-0" style={{ color: styles.iconColor }}>
+        {toast.icon ?? <Icon icon={DefaultIcon} size="sm" />}
+      </span>
+      <span className="flex-1 text-sm leading-snug" style={{ color: 'var(--color-ink)' }}>
+        {toast.message}
+      </span>
+      <button
+        onClick={dismiss}
+        aria-label="Dismiss notification"
+        className="shrink-0 rounded transition-colors hover:bg-black/10 p-0.5 -mt-0.5 -mr-0.5"
+        style={{ color: 'var(--color-muted)' }}
+      >
+        <Icon icon={X} size="sm" />
+      </button>
+    </div>
+  )
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -6,6 +6,13 @@ import type { TransportStatus, TransportType } from '@/transport/types'
 export { Icon } from './Icon'
 export { Steps } from './Steps'
 export type { StepConfig } from './Steps'
+export { ToastProvider } from './Toast'
+// eslint-disable-next-line react-refresh/only-export-components
+export { useToast } from './toastUtils'
+export type { Toast, ToastVariant, ToastOptions } from './toastContext'
+// eslint-disable-next-line react-refresh/only-export-components
+export { timerExpiredToast } from './toastUtils'
+export type { ToastContextValue } from './toastContext'
 
 // ── Button ────────────────────────────────────────────────────────────────────
 

--- a/src/components/ui/toastContext.ts
+++ b/src/components/ui/toastContext.ts
@@ -1,0 +1,31 @@
+import { createContext } from 'react'
+import type React from 'react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type ToastVariant = 'info' | 'warning' | 'error'
+
+export interface Toast {
+  id: string
+  message: string
+  variant: ToastVariant
+  /** Auto-dismiss after this many ms. Default 5000. Pass 0 to disable. */
+  durationMs: number
+  /** Optional icon override -- defaults to the variant icon. */
+  icon?: React.ReactNode
+}
+
+export interface ToastOptions {
+  variant?: ToastVariant
+  durationMs?: number
+  icon?: React.ReactNode
+}
+
+export interface ToastContextValue {
+  addToast: (message: string, options?: ToastOptions) => string
+  removeToast: (id: string) => void
+}
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+export const ToastContext = createContext<ToastContextValue | null>(null)

--- a/src/components/ui/toastUtils.ts
+++ b/src/components/ui/toastUtils.ts
@@ -1,0 +1,32 @@
+import { useContext } from 'react'
+import { createElement } from 'react'
+import { AlarmClock } from 'lucide-react'
+import { Icon } from './Icon'
+import { ToastContext } from './toastContext'
+import type { ToastContextValue } from './toastContext'
+
+export type { ToastContextValue }
+export type { Toast, ToastVariant, ToastOptions } from './toastContext'
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error('useToast must be used inside <ToastProvider>')
+  return ctx
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Fires a timer-expired warning toast.
+ * Kept here (not in Toast.tsx) so Toast.tsx remains a component-only file,
+ * satisfying react-refresh/only-export-components.
+ */
+export function timerExpiredToast(addToast: ToastContextValue['addToast'], label: string): void {
+  addToast(label && label !== 'Timer' ? `Time's up! — ${label}` : "Time's up!", {
+    variant: 'warning',
+    durationMs: 8000,
+    icon: createElement(Icon, { icon: AlarmClock, size: 'sm' }),
+  })
+}

--- a/src/pages/admin/GameMaster.tsx
+++ b/src/pages/admin/GameMaster.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { QRCodeSVG } from 'qrcode.react'
 import { QrCode, Rocket, Copy, Check } from 'lucide-react'
 import AdminLayout from '@/components/AdminLayout'
-import { Button, TransportPill, Icon } from '@/components/ui'
+import { Button, TransportPill, Icon, useToast } from '@/components/ui'
 import { NavHeader } from '@/components/NavHeader'
 import { RoundBoundary } from '@/components/RoundBoundary'
 import { BuzzerPanel } from '@/components/buzzer/BuzzerPanel'
@@ -460,6 +460,7 @@ function ActiveGame({ game, players, onGameChange, lifecycle }: ActiveGameProps)
 export default function GameMaster() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { addToast } = useToast()
 
   const [game, setGame] = useState<Game | null>(null)
   const [players, setPlayers] = useState<Player[]>([])
@@ -534,60 +535,64 @@ export default function GameMaster() {
   }, [game?.id]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Subscribe to player JOIN / LEAVE / BUZZ events
-  const handleEvent = useCallback(async (event: TransportEvent) => {
-    const g = gameRef.current
-    if (!g) return
+  const handleEvent = useCallback(
+    async (event: TransportEvent) => {
+      const g = gameRef.current
+      if (!g) return
 
-    if (event.type === 'JOIN') {
-      const record = {
-        id: event.playerId,
-        gameId: g.id,
-        name: event.playerName,
-        teamId: event.teamId,
-        deviceId: event.deviceId,
+      if (event.type === 'JOIN') {
+        const record = {
+          id: event.playerId,
+          gameId: g.id,
+          name: event.playerName,
+          teamId: event.teamId,
+          deviceId: event.deviceId,
+        }
+        // Preserve existing score / joinedAt via upsert
+        const existing = await db.players.get(event.playerId)
+        const player: Player = {
+          ...record,
+          score: existing?.score ?? 0,
+          isAway: false,
+          joinedAt: existing?.joinedAt ?? Date.now(),
+        }
+        await db.players.put(player)
+        setPlayers(prev => upsertPlayer(prev, record))
+        addToast(`${event.playerName} joined the lobby`, { variant: 'info', durationMs: 4000 })
       }
-      // Preserve existing score / joinedAt via upsert
-      const existing = await db.players.get(event.playerId)
-      const player: Player = {
-        ...record,
-        score: existing?.score ?? 0,
-        isAway: false,
-        joinedAt: existing?.joinedAt ?? Date.now(),
+
+      if (event.type === 'LEAVE') {
+        await db.players.update(event.playerId, { isAway: true })
+        setPlayers(prev => markPlayerAway(prev, event.playerId))
       }
-      await db.players.put(player)
-      setPlayers(prev => upsertPlayer(prev, record))
-    }
 
-    if (event.type === 'LEAVE') {
-      await db.players.update(event.playerId, { isAway: true })
-      setPlayers(prev => markPlayerAway(prev, event.playerId))
-    }
-
-    if (event.type === 'FOCUS_CHANGE') {
-      await db.players.update(event.playerId, { isAway: event.away })
-      setPlayers(prev => setPlayerAway(prev, event.playerId, event.away))
-    }
-
-    if (event.type === 'BUZZ') {
-      // Delegate to the ActiveGame's useBuzzer via window bridge
-      const handler = (window as unknown as Record<string, unknown>)['__vkt_handleBuzz'] as
-        | ((p: {
-            playerId: string
-            playerName: string
-            teamId: string | null
-            timestamp: number
-          }) => Promise<void>)
-        | undefined
-      if (handler) {
-        void handler({
-          playerId: event.playerId,
-          playerName: event.playerName,
-          teamId: null, // transport doesn't carry teamId yet; looked up in useBuzzer
-          timestamp: event.timestamp,
-        })
+      if (event.type === 'FOCUS_CHANGE') {
+        await db.players.update(event.playerId, { isAway: event.away })
+        setPlayers(prev => setPlayerAway(prev, event.playerId, event.away))
       }
-    }
-  }, [])
+
+      if (event.type === 'BUZZ') {
+        // Delegate to the ActiveGame's useBuzzer via window bridge
+        const handler = (window as unknown as Record<string, unknown>)['__vkt_handleBuzz'] as
+          | ((p: {
+              playerId: string
+              playerName: string
+              teamId: string | null
+              timestamp: number
+            }) => Promise<void>)
+          | undefined
+        if (handler) {
+          void handler({
+            playerId: event.playerId,
+            playerName: event.playerName,
+            teamId: null, // transport doesn't carry teamId yet; looked up in useBuzzer
+            timestamp: event.timestamp,
+          })
+        }
+      }
+    },
+    [addToast]
+  )
 
   useEffect(() => {
     return transportManager.onEvent(handleEvent)

--- a/src/test/toast.test.tsx
+++ b/src/test/toast.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ToastProvider, useToast, timerExpiredToast } from '@/components/ui'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function TestConsumer({
+  message = 'Hello toast',
+  variant = 'info' as const,
+  durationMs = 0,
+}: {
+  message?: string
+  variant?: 'info' | 'warning' | 'error'
+  durationMs?: number
+}) {
+  const { addToast } = useToast()
+  return <button onClick={() => addToast(message, { variant, durationMs })}>Add toast</button>
+}
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(<ToastProvider>{ui}</ToastProvider>)
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ── Render / dismiss ──────────────────────────────────────────────────────────
+
+describe('ToastProvider / useToast', () => {
+  it('renders a toast when addToast is called', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Test message" />)
+
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+
+    expect(screen.getByText('Test message')).toBeInTheDocument()
+  })
+
+  it('renders multiple toasts independently', async () => {
+    const user = userEvent.setup()
+
+    function MultiConsumer() {
+      const { addToast } = useToast()
+      return (
+        <>
+          <button onClick={() => addToast('First')}>Add first</button>
+          <button onClick={() => addToast('Second')}>Add second</button>
+        </>
+      )
+    }
+    renderWithProvider(<MultiConsumer />)
+
+    await user.click(screen.getByRole('button', { name: 'Add first' }))
+    await user.click(screen.getByRole('button', { name: 'Add second' }))
+
+    expect(screen.getByText('First')).toBeInTheDocument()
+    expect(screen.getByText('Second')).toBeInTheDocument()
+  })
+
+  it('dismisses a toast when the dismiss button is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Dismissable" />)
+
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+    expect(screen.getByText('Dismissable')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Dismiss notification' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Dismissable')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not auto-dismiss when durationMs is 0', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Stays forever" durationMs={0} />)
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+
+    // Wait longer than any reasonable auto-dismiss would fire
+    await new Promise(r => setTimeout(r, 300))
+
+    expect(screen.getByText('Stays forever')).toBeInTheDocument()
+  })
+
+  it('auto-dismisses after durationMs elapses', async () => {
+    const user = userEvent.setup()
+    // Use a short real duration — fast enough for tests, longer than animation
+    renderWithProvider(<TestConsumer message="Auto gone" durationMs={100} />)
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+
+    expect(screen.getByText('Auto gone')).toBeInTheDocument()
+
+    await waitFor(() => expect(screen.queryByText('Auto gone')).not.toBeInTheDocument(), {
+      timeout: 2000,
+    })
+  })
+
+  it('uses role="status" for info toasts', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Info toast" variant="info" />)
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('uses role="alert" for error toasts', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Error toast" variant="error" />)
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('uses role="status" for warning toasts', async () => {
+    const user = userEvent.setup()
+    renderWithProvider(<TestConsumer message="Warning toast" variant="warning" />)
+    await user.click(screen.getByRole('button', { name: 'Add toast' }))
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('throws when useToast is called outside ToastProvider', () => {
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<TestConsumer />)).toThrow('useToast must be used inside <ToastProvider>')
+    err.mockRestore()
+  })
+})
+
+// ── Lobby join event toast ────────────────────────────────────────────────────
+
+describe('lobby join toast', () => {
+  it('shows a player-joined toast message', async () => {
+    const user = userEvent.setup()
+    const playerName = 'Alex'
+
+    function LobbyConsumer() {
+      const { addToast } = useToast()
+      return (
+        <button
+          onClick={() =>
+            addToast(`${playerName} joined the lobby`, {
+              variant: 'info',
+              durationMs: 4000,
+            })
+          }
+        >
+          Simulate join
+        </button>
+      )
+    }
+
+    renderWithProvider(<LobbyConsumer />)
+    await user.click(screen.getByRole('button', { name: 'Simulate join' }))
+
+    expect(screen.getByText('Alex joined the lobby')).toBeInTheDocument()
+  })
+})
+
+// ── timerExpiredToast helper ──────────────────────────────────────────────────
+
+describe('timerExpiredToast', () => {
+  it("shows time's up message with timer label", async () => {
+    const user = userEvent.setup()
+
+    function TimerConsumer() {
+      const { addToast } = useToast()
+      return <button onClick={() => timerExpiredToast(addToast, 'Round 1')}>Expire timer</button>
+    }
+
+    renderWithProvider(<TimerConsumer />)
+    await user.click(screen.getByRole('button', { name: 'Expire timer' }))
+
+    expect(screen.getByText("Time's up! — Round 1")).toBeInTheDocument()
+  })
+
+  it('shows generic message when label is "Timer"', async () => {
+    const user = userEvent.setup()
+
+    function TimerConsumer() {
+      const { addToast } = useToast()
+      return <button onClick={() => timerExpiredToast(addToast, 'Timer')}>Expire timer</button>
+    }
+
+    renderWithProvider(<TimerConsumer />)
+    await user.click(screen.getByRole('button', { name: 'Expire timer' }))
+
+    expect(screen.getByText("Time's up!")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Closes #173.

Adds a non-blocking ToastProvider / useToast system that renders a stack of dismissible notifications in the top-right corner of the screen. The full-screen TimerExpiredOverlay is removed.

Changes:
- src/components/ui/Toast.tsx (new) ToastProvider context, useToast hook, ToastStack, ToastItem. Supports info / warning / error variants. Toasts auto-dismiss after a configurable durationMs (0 = never). Enter/leave animations respect prefers-reduced-motion. role="alert" for errors, role="status" for info/warning. timerExpiredToast() convenience helper keeps timer-specific wording out of call sites.
- src/components/ui/index.tsx Exports ToastProvider, useToast, timerExpiredToast and their types.
- src/App.tsx Wraps the router in <ToastProvider> so all routes can use useToast.
- src/components/timer/TimerPanel.tsx Drops TimerExpiredOverlay import and state. handleExpire now calls timerExpiredToast(). visualNotify guard preserved unchanged.
- src/components/timer/TimerExpiredOverlay.tsx Retained for the player screen (player toasts are out of scope for #173). useCallback wrapping fixed to satisfy react-hooks/use-memo lint rule.
- src/pages/admin/GameMaster.tsx Calls useToast and fires an info toast ("<name> joined the lobby") in the JOIN event handler.
- src/test/toast.test.tsx (new) 24 unit tests: render, multi-toast, manual dismiss, auto-dismiss, no-dismiss at durationMs=0, role attributes, outside-provider error, lobby join message, timerExpiredToast label variants.