### PR TITLE
fix(ui): add multi-select checkboxes to team list

### DIFF
--- a/src/components/players-teams/TeamBulkActionBar.tsx
+++ b/src/components/players-teams/TeamBulkActionBar.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { useLiveQuery } from 'dexie-react-hooks'
+import { db } from '@/db'
+import { Button, Modal } from '@/components/ui'
+
+interface Props {
+  selectedIds: Set<string>
+  onDone: () => void
+}
+
+type Action = 'add-label' | 'remove-label' | 'archive' | 'archive-confirm' | null
+
+export default function TeamBulkActionBar({ selectedIds, onDone }: Props) {
+  const labels = useLiveQuery(() => db.managedLabels.orderBy('name').toArray(), [])
+
+  const [action, setAction] = useState<Action>(null)
+  const [busy, setBusy] = useState(false)
+
+  const count = selectedIds.size
+
+  async function handleAddLabel(labelId: string) {
+    setBusy(true)
+    try {
+      const teams = await db.managedTeams.bulkGet([...selectedIds])
+      await Promise.all(
+        teams.map(t => {
+          if (!t || t.labelIds.includes(labelId)) return
+          return db.managedTeams.update(t.id, {
+            labelIds: [...t.labelIds, labelId],
+          })
+        })
+      )
+    } finally {
+      setBusy(false)
+      setAction(null)
+      onDone()
+    }
+  }
+
+  async function handleRemoveLabel(labelId: string) {
+    setBusy(true)
+    try {
+      const teams = await db.managedTeams.bulkGet([...selectedIds])
+      await Promise.all(
+        teams.map(t => {
+          if (!t || !t.labelIds.includes(labelId)) return
+          return db.managedTeams.update(t.id, {
+            labelIds: t.labelIds.filter(id => id !== labelId),
+          })
+        })
+      )
+    } finally {
+      setBusy(false)
+      setAction(null)
+      onDone()
+    }
+  }
+
+  async function handleArchiveConfirm() {
+    setBusy(true)
+    try {
+      await Promise.all(
+        [...selectedIds].map(id => db.managedTeams.update(id, { archivedAt: new Date() }))
+      )
+    } finally {
+      setBusy(false)
+      setAction(null)
+      onDone()
+    }
+  }
+
+  return (
+    <>
+      {/* Sticky bar */}
+      <div
+        className="flex items-center gap-2 px-3 py-2 mt-2 rounded-lg border"
+        style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+        role="toolbar"
+        aria-label="Bulk actions"
+      >
+        <span className="text-xs font-medium mr-1" style={{ color: 'var(--color-ink)' }}>
+          {count} selected
+        </span>
+        <div className="flex-1" />
+        <button
+          onClick={() => setAction('add-label')}
+          className="text-xs px-2.5 py-1.5 rounded border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--color-border)', color: 'var(--color-ink)' }}
+          aria-label="Add label to selected teams"
+        >
+          Add label
+        </button>
+        <button
+          onClick={() => setAction('remove-label')}
+          className="text-xs px-2.5 py-1.5 rounded border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--color-border)', color: 'var(--color-ink)' }}
+          aria-label="Remove label from selected teams"
+        >
+          Remove label
+        </button>
+        <button
+          onClick={() => setAction('archive')}
+          className="text-xs px-2.5 py-1.5 rounded border transition-colors hover:bg-black/5"
+          style={{ borderColor: 'var(--color-red)', color: 'var(--color-red)' }}
+          aria-label="Archive selected teams"
+        >
+          Archive
+        </button>
+        <button
+          onClick={onDone}
+          className="text-xs px-2 py-1.5 rounded transition-colors hover:bg-black/5"
+          style={{ color: 'var(--color-muted)' }}
+          aria-label="Clear selection"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Add label picker */}
+      <Modal
+        open={action === 'add-label'}
+        onClose={() => setAction(null)}
+        title="Add label"
+        maxWidth="320px"
+      >
+        <div className="flex flex-col gap-2">
+          <p className="text-xs mb-1" style={{ color: 'var(--color-muted)' }}>
+            Add label to {count} team{count !== 1 ? 's' : ''}:
+          </p>
+          {(labels ?? []).map(label => (
+            <button
+              key={label.id}
+              onClick={() => handleAddLabel(label.id)}
+              disabled={busy}
+              className="flex items-center gap-2 px-3 py-2 rounded border text-sm text-left transition-colors hover:bg-black/5 disabled:opacity-50"
+              style={{ borderColor: 'var(--color-border)' }}
+            >
+              <span
+                className="w-3 h-3 rounded-full shrink-0"
+                style={{ background: label.color }}
+                aria-hidden
+              />
+              {label.name}
+            </button>
+          ))}
+          {(labels ?? []).length === 0 && (
+            <p className="text-xs text-center py-4" style={{ color: 'var(--color-muted)' }}>
+              No labels yet
+            </p>
+          )}
+        </div>
+      </Modal>
+
+      {/* Remove label picker */}
+      <Modal
+        open={action === 'remove-label'}
+        onClose={() => setAction(null)}
+        title="Remove label"
+        maxWidth="320px"
+      >
+        <div className="flex flex-col gap-2">
+          <p className="text-xs mb-1" style={{ color: 'var(--color-muted)' }}>
+            Remove label from {count} team{count !== 1 ? 's' : ''}:
+          </p>
+          {(labels ?? []).map(label => (
+            <button
+              key={label.id}
+              onClick={() => handleRemoveLabel(label.id)}
+              disabled={busy}
+              className="flex items-center gap-2 px-3 py-2 rounded border text-sm text-left transition-colors hover:bg-black/5 disabled:opacity-50"
+              style={{ borderColor: 'var(--color-border)' }}
+            >
+              <span
+                className="w-3 h-3 rounded-full shrink-0"
+                style={{ background: label.color }}
+                aria-hidden
+              />
+              {label.name}
+            </button>
+          ))}
+        </div>
+      </Modal>
+
+      {/* Archive step 1 — confirm */}
+      <Modal
+        open={action === 'archive'}
+        onClose={() => setAction(null)}
+        title="Archive teams?"
+        maxWidth="320px"
+      >
+        <div className="flex flex-col gap-3">
+          <p className="text-sm" style={{ color: 'var(--color-ink)' }}>
+            Archiving {count} team{count !== 1 ? 's' : ''}. Records will appear greyed-out in-place.
+            No undo.
+          </p>
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="ghost" onClick={() => setAction(null)}>
+              Cancel
+            </Button>
+            <Button variant="danger" onClick={handleArchiveConfirm} disabled={busy}>
+              {busy ? 'Archiving...' : 'Archive'}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/src/components/players-teams/TeamList.tsx
+++ b/src/components/players-teams/TeamList.tsx
@@ -6,6 +6,7 @@ import { Empty, Icon } from '@/components/ui'
 import { resolveIcon } from './teamIcons'
 import TeamForm from './TeamForm'
 import TeamQrModal from './TeamQrModal'
+import TeamBulkActionBar from './TeamBulkActionBar'
 
 type LabelFilter = Record<string, 'include' | 'exclude'>
 
@@ -34,19 +35,35 @@ export default function TeamList({
 }: Props) {
   const teams = useLiveQuery(() => db.managedTeams.orderBy('name').toArray(), [])
 
-  const [editing, setEditing] = useState<ManagedTeam | null | undefined>(undefined)
-  const [qrTarget, setQrTarget] = useState<ManagedTeam | null>(null)
-  // undefined = form closed, null = new team, ManagedTeam = editing existing
-
   const visible = (teams ?? []).filter(t => {
     if (search && !t.name.toLowerCase().includes(search.toLowerCase())) return false
     if (Object.keys(labelFilter).length > 0 && !matchesLabelFilter(t.labelIds, labelFilter))
       return false
     return true
   })
-
   const active = visible.filter(t => !t.archivedAt)
   const archived = visible.filter(t => t.archivedAt)
+
+  const [editing, setEditing] = useState<ManagedTeam | null | undefined>(undefined)
+  const [qrTarget, setQrTarget] = useState<ManagedTeam | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  const activeIds = active.map(t => t.id)
+  const allSelected = activeIds.length > 0 && activeIds.every(id => selected.has(id))
+  const someSelected = selected.size > 0
+
+  function toggleOne(id: string) {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function toggleAll() {
+    setSelected(allSelected ? new Set() : new Set(activeIds))
+  }
 
   async function archive(t: ManagedTeam) {
     await db.managedTeams.update(t.id, { archivedAt: new Date() })
@@ -65,6 +82,24 @@ export default function TeamList({
         className="rounded-lg overflow-hidden border"
         style={{ borderColor: 'var(--color-border)' }}
       >
+        {active.length > 0 && (
+          <div
+            className="flex items-center gap-3 px-3 py-2 border-b"
+            style={{ borderColor: 'var(--color-border)', background: 'var(--color-surface)' }}
+          >
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleAll}
+              aria-label="Select all teams"
+              className="w-3.5 h-3.5 cursor-pointer"
+            />
+            <span className="text-xs" style={{ color: 'var(--color-muted)' }}>
+              {someSelected ? `${selected.size} selected` : 'Select all'}
+            </span>
+          </div>
+        )}
+
         {active.length === 0 && archived.length === 0 && (
           <Empty
             message={
@@ -78,6 +113,8 @@ export default function TeamList({
             key={team.id}
             team={team}
             selected={selectedTeamId === team.id}
+            checked={selected.has(team.id)}
+            onCheck={() => toggleOne(team.id)}
             onClick={() => onSelect?.(selectedTeamId === team.id ? null : team.id)}
             onEdit={() => setEditing(team)}
             onArchive={() => archive(team)}
@@ -89,6 +126,10 @@ export default function TeamList({
           <TeamRow key={team.id} team={team} archived onRestore={() => restore(team)} />
         ))}
       </div>
+
+      {someSelected && (
+        <TeamBulkActionBar selectedIds={selected} onDone={() => setSelected(new Set())} />
+      )}
 
       <TeamForm
         open={editing !== undefined}
@@ -105,6 +146,8 @@ export default function TeamList({
 interface RowProps {
   team: ManagedTeam
   selected?: boolean
+  checked?: boolean
+  onCheck?: () => void
   archived?: boolean
   onClick?: () => void
   onEdit?: () => void
@@ -116,6 +159,8 @@ interface RowProps {
 function TeamRow({
   team,
   selected,
+  checked,
+  onCheck,
   archived,
   onClick,
   onEdit,
@@ -139,6 +184,18 @@ function TeamRow({
       aria-pressed={selected}
       aria-label={archived ? undefined : `${selected ? 'Deselect' : 'Select'} team ${team.name}`}
     >
+      {/* Checkbox — active rows only */}
+      {!archived && (
+        <input
+          type="checkbox"
+          checked={checked ?? false}
+          onChange={onCheck}
+          onClick={e => e.stopPropagation()}
+          aria-label={`Select ${team.name}`}
+          className="w-3.5 h-3.5 cursor-pointer shrink-0"
+        />
+      )}
+
       {/* Badge */}
       <span
         className="w-6 h-6 rounded flex items-center justify-center shrink-0 text-white"


### PR DESCRIPTION
Closes #152.

TeamList had no checkbox system -- rows were click-to-select for player-pane filtering only. This adds parity with PlayerList:

- Select-all header checkbox with selected-count label
- Per-row checkbox on every active TeamRow (stopPropagation so checking does not also toggle the team filter selection)
- TeamBulkActionBar (new component) shown when one or more teams are checked; supports bulk add-label, remove-label, and two-step archive confirmation -- matching the player bulk bar pattern